### PR TITLE
Corrected transformation matrix for Node

### DIFF
--- a/sceneview/src/main/kotlin/io/github/sceneview/node/Node.kt
+++ b/sceneview/src/main/kotlin/io/github/sceneview/node/Node.kt
@@ -153,7 +153,7 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
     var scale: Scale = DEFAULT_SCALE
 
     open var transform: Transform
-        get() = transpose(translation(position) * rotation(rotationQuaternion) * scale(scale))
+        get() = translation(position) * rotation(rotationQuaternion) * scale(scale)
         set(value) {
             position = Position(value.position)
             rotationQuaternion = rotation(value).toQuaternion()
@@ -207,7 +207,7 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
     open var contentScale = Scale(1.0f, 1.0f, 1.0f)
 
     open var contentTransform: Transform
-        get() = transpose(translation(contentPosition) * rotation(contentRotationQuaternion) * scale(contentScale))
+        get() = translation(contentPosition) * rotation(contentRotationQuaternion) * scale(contentScale)
         set(value) {
             contentPosition = Position(value.position)
             contentRotationQuaternion = rotation(value).toQuaternion()
@@ -614,7 +614,7 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
 
     // TODO : Remove this to full Kotlin Math
     override fun getTransformationMatrix(): Matrix {
-        return Matrix(worldTransform.toFloatArray())
+        return Matrix(worldTransform.toColumnsFloatArray())
     }
 
     // Reuse this to limit frame instantiations

--- a/sceneview/src/main/kotlin/io/github/sceneview/utils/Math.kt
+++ b/sceneview/src/main/kotlin/io/github/sceneview/utils/Math.kt
@@ -32,4 +32,11 @@ fun Quaternion.toOldQuaternion() = com.google.ar.sceneform.math.Quaternion(x, y,
 //TODO: Remove when everything use Quaternion
 fun com.google.ar.sceneform.math.Quaternion.toNewQuaternion() = Quaternion(x, y, z, w)
 
+fun Mat4.toColumnsFloatArray() = floatArrayOf(
+    x.x, x.y, x.z, x.w,
+    y.x, y.y, y.z, y.w,
+    z.x, z.y, z.z, z.w,
+    w.x, w.y, w.z, w.w
+)
+
 fun lerp(a: Float3, b: Float3, t:Float) = mix(a, b, t)


### PR DESCRIPTION
Hi @romainguy!
We've been a little bit confused about whether we need to transpose the transformation matrices or not. It turns out that Kotlin-Math returns a row major array from the `toFloatArray()` method.
https://github.com/romainguy/kotlin-math/blob/cb83e255521ea3247beb642ee24625538e7b2439/src/commonMain/kotlin/dev/romainguy/kotlin/math/Matrix.kt#L371
I'm interested why you've chosen this format instead of a column major array that is used in OpenGL and Filament.