### PR TITLE
Changed the default mode for the PlaneRenderer.

### DIFF
--- a/arsceneview/src/main/kotlin/io/github/sceneview/ar/scene/PlaneRenderer.kt
+++ b/arsceneview/src/main/kotlin/io/github/sceneview/ar/scene/PlaneRenderer.kt
@@ -71,7 +71,7 @@ class PlaneRenderer(val lifecycle: ArSceneLifecycle) : ArSceneLifecycleObserver 
      *
      * @param planeRendererMode [PlaneRendererMode]
      */
-    var planeRendererMode = PlaneRendererMode.RENDER_ALL
+    var planeRendererMode = PlaneRendererMode.RENDER_TOP_MOST
 
     // Distance from the camera to last plane hit, default value is 4 meters (standing height).
     private var planeHitDistance = 4.0f


### PR DESCRIPTION
**PlaneRenderMode.RENDER_ALL** was set as the default mode but the doc states clearly that this mode is very expensive. A short check on the Profile verified this statement with 500ms spikes. The default mode is now set to **PlaneRenderMode.RENDER_TOP_MOST**.