### PR TITLE
Supported setting world position, quaternion, rotation and scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a Sceneform replacement in Kotlin
 - Lifecycle-aware components = Better memory management and performance.
 - Resources are loaded using coroutines launched in the `LifecycleCoroutineScope` of the `SceneView`/`ArSceneView`. This means that loading is started when the view is created and cancelled when it is destroyed.
 - Multiple instances are now possible.
-- Much easier to use. For example, the local and world `position`, `rotation` and `scale` of the `Node` are now directly accessible without creating ~`Vector3`~ objects (`position.x = 1f`, `rotation.xy = Float2(90f, 180f)`, `scale = Scale(0.5f)`, etc.).
+- Much easier to use. For example, the local and world `position`, `rotation` and `scale` of the `Node` are now directly accessible without creating ~`Vector3`~ objects (`position.x = 1f`, `rotation = Rotation(90f, 180f, 0f)`, `scale = Scale(0.5f)`, etc.).
 
 ## Dependency
 

--- a/sceneview/src/main/java/io/github/sceneview/node/Node.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/Node.kt
@@ -125,6 +125,8 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
      * The default rotation is the zero vector, specifying no rotation.
      * Rotation is applied relative to the node's origin property.
      *
+     * Note that modifying the individual components of the returned rotation doesn't have any effect.
+     *
      * ------- +y ----- -z
      *
      * ---------|----/----
@@ -163,6 +165,75 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
         }
 
     /**
+     * ### The node world-space position
+     *
+     * The world position of this node (i.e. relative to the [SceneView]).
+     * This is the composition of this component's local position with its parent's world
+     * position.
+     *
+     * @see worldTransform
+     */
+    open var worldPosition: Position
+        get() = worldTransform.position
+        set(value) {
+            position = (worldToParent * Float4(value, 1f)).xyz
+        }
+
+    /**
+     * ### The node world-space quaternion
+     *
+     * The world quaternion of this node (i.e. relative to the [SceneView]).
+     * This is the composition of this component's local quaternion with its parent's world
+     * quaternion.
+     *
+     * @see worldTransform
+     */
+    open var worldQuaternion: Quaternion
+        get() = worldTransform.toQuaternion()
+        set(value) {
+            quaternion = worldToParent.toQuaternion() * value
+        }
+
+    /**
+     * ### The node world-space rotation
+     *
+     * The world rotation of this node (i.e. relative to the [SceneView]).
+     * This is the composition of this component's local rotation with its parent's world
+     * rotation.
+     *
+     * @see worldTransform
+     */
+    open var worldRotation: Rotation
+        get() = worldTransform.rotation
+        set(value) {
+            quaternion = worldToParent.toQuaternion() * Quaternion.fromEuler(value)
+        }
+
+    /**
+     * ### The node world-space scale
+     *
+     * The world scale of this node (i.e. relative to the [SceneView]).
+     * This is the composition of this component's local scale with its parent's world
+     * scale.
+     *
+     * @see worldTransform
+     */
+    open var worldScale: Scale
+        get() = worldTransform.scale
+        set(value) {
+            scale = (worldToParent * scale(value)).scale
+        }
+
+    open val worldTransform: Mat4
+        get() = parentNode?.let { it.worldTransform * transform } ?: transform
+
+    /**
+     * ### The transform from the world coordinate system to the coordinate system of the parent node
+     */
+    private val worldToParent: Transform
+        get() = parentNode?.let { inverse(it.worldTransform) } ?: Transform()
+
+    /**
      * ## The smooth position, rotation and scale speed
      *
      * Expressed in units per seconds.
@@ -186,11 +257,6 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
 
     private var smoothPosition: Position? = null
     private var smoothQuaternion: Quaternion? = null
-
-    open val worldTransform: Mat4
-        get() = (parentNode?.let { parent ->
-            parent.worldTransform * transform
-        } ?: transform)
 
     /**
      * ### The node can be focused within the [com.google.ar.sceneform.collision.CollisionSystem]
@@ -543,39 +609,6 @@ open class Node : NodeParent, TransformProvider, SceneLifecycleObserver {
      */
     fun isDescendantOf(ancestor: NodeParent): Boolean =
         parent == ancestor || parentNode?.isDescendantOf(ancestor) == true
-
-    /**
-     * ### The node world-space position
-     *
-     * The world position of this node (i.e. relative to the [SceneView]).
-     * This is the composition of this component's local position with its parent's world
-     * position.
-     *
-     * @see worldTransform
-     */
-    open val worldPosition: Position get() = worldTransform.position
-
-    /**
-     * ### The node world-space rotation
-     *
-     * The world rotation of this node (i.e. relative to the [SceneView]).
-     * This is the composition of this component's local rotation with its parent's world
-     * rotation.
-     *
-     * @see worldTransform
-     */
-    open val worldRotation: Rotation get() = worldTransform.rotation
-
-    /**
-     * ### The node world-space scale
-     *
-     * The world scale of this node (i.e. relative to the [SceneView]).
-     * This is the composition of this component's local scale with its parent's world
-     * scale.
-     *
-     * @see worldTransform
-     */
-    open val worldScale: Scale get() = worldTransform.scale
 
     // TODO : Remove this to full Kotlin Math
     override fun getTransformationMatrix(): Matrix {


### PR DESCRIPTION
I've also added a note about setting the individual components of the rotation and moved the `world` properties next to the `local` ones.