### PR TITLE
Allow gesture detectors to be changed at runtime

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/interaction/SceneGestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/interaction/SceneGestureDetector.kt
@@ -55,15 +55,14 @@ open class SceneGestureDetector(
             field = it
         }
 
-    private val gestureDetectors: List<*> by lazy {
-        listOfNotNull(
+    private val gestureDetectors: List<*>
+        get() = listOfNotNull(
             gestureDetector,
             moveGestureDetector,
             scaleGestureDetector,
             rotateGestureDetector,
             filamentGestureDetector
         )
-    }
 
     var lastTouchEvent: MotionEvent? = null
 


### PR DESCRIPTION
Gesture detectors are vars and can be changed all the times. But the gestureDetectors list is not updated after it's lazily initialized.

For performance reason it would also be an option to remove this list completely and call the detectors in onTouch() directly.