### PR TITLE
Small improvements

### DIFF
--- a/samples/ar-cloud-anchor/src/main/java/io/github/sceneview/sample/arcloudanchor/Activity.kt
+++ b/samples/ar-cloud-anchor/src/main/java/io/github/sceneview/sample/arcloudanchor/Activity.kt
@@ -14,8 +14,10 @@ class Activity : AppCompatActivity(R.layout.activity) {
         super.onCreate(savedInstanceState)
 
         setFullScreen(
-            fullScreen = true, hideSystemBars = false,
-            fitsSystemWindows = false, rootView = findViewById(R.id.rootView)
+            findViewById(R.id.rootView),
+            fullScreen = true,
+            hideSystemBars = false,
+            fitsSystemWindows = false
         )
 
         setSupportActionBar(findViewById<Toolbar>(R.id.toolbar)?.apply {

--- a/samples/ar-cursor-placement/src/main/java/io/github/sceneview/sample/arcursorplacement/Activity.kt
+++ b/samples/ar-cursor-placement/src/main/java/io/github/sceneview/sample/arcursorplacement/Activity.kt
@@ -14,8 +14,10 @@ class Activity : AppCompatActivity(R.layout.activity) {
         super.onCreate(savedInstanceState)
 
         setFullScreen(
-            fullScreen = true, hideSystemBars = false,
-            fitsSystemWindows = false, rootView = findViewById(R.id.rootView)
+            findViewById(R.id.rootView),
+            fullScreen = true,
+            hideSystemBars = false,
+            fitsSystemWindows = false
         )
 
         setSupportActionBar(findViewById<Toolbar>(R.id.toolbar)?.apply {

--- a/samples/ar-model-viewer/src/main/java/io/github/sceneview/sample/armodelviewer/Activity.kt
+++ b/samples/ar-model-viewer/src/main/java/io/github/sceneview/sample/armodelviewer/Activity.kt
@@ -14,8 +14,10 @@ class Activity : AppCompatActivity(R.layout.activity) {
         super.onCreate(savedInstanceState)
 
         setFullScreen(
-            fullScreen = true, hideSystemBars = false,
-            fitsSystemWindows = false, rootView = findViewById(R.id.rootView)
+            findViewById(R.id.rootView),
+            fullScreen = true,
+            hideSystemBars = false,
+            fitsSystemWindows = false
         )
 
         setSupportActionBar(findViewById<Toolbar>(R.id.toolbar)?.apply {

--- a/samples/model-viewer/src/main/java/io/github/sceneview/sample/modelviewer/Activity.kt
+++ b/samples/model-viewer/src/main/java/io/github/sceneview/sample/modelviewer/Activity.kt
@@ -14,8 +14,10 @@ class Activity : AppCompatActivity(R.layout.activity) {
         super.onCreate(savedInstanceState)
 
         setFullScreen(
-            fullScreen = true, hideSystemBars = false,
-            fitsSystemWindows = false, rootView = findViewById(R.id.rootView)
+            findViewById(R.id.rootView),
+            fullScreen = true,
+            hideSystemBars = false,
+            fitsSystemWindows = false
         )
 
         setSupportActionBar(findViewById<Toolbar>(R.id.toolbar)?.apply {

--- a/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
@@ -163,6 +163,8 @@ open class ViewNode : Node {
         }
     }
 
+    // TODO: Add a method for setting the View from code and support setting the view sizer and alignment
+
     open fun setRenderable(renderable: ViewRenderable?): RenderableInstance? {
         renderableInstance = renderable?.createInstance(this)
         return renderableInstance

--- a/sceneview/src/main/java/io/github/sceneview/utils/Screen.kt
+++ b/sceneview/src/main/java/io/github/sceneview/utils/Screen.kt
@@ -27,10 +27,10 @@ fun Fragment.setFullScreen(
     fitsSystemWindows: Boolean = true
 ) {
     requireActivity().setFullScreen(
-        fullScreen = fullScreen,
-        rootView = this.requireView(),
-        hideSystemBars = hideSystemBars,
-        fitsSystemWindows = fitsSystemWindows
+        this.requireView(),
+        fullScreen,
+        hideSystemBars,
+        fitsSystemWindows
     )
 }
 
@@ -41,19 +41,19 @@ fun View.setFullScreen(
 ) {
     doOnActivityAttach { activity ->
         activity.setFullScreen(
-            fullScreen = fullScreen,
-            rootView = this,
-            hideSystemBars = hideSystemBars,
-            fitsSystemWindows = fitsSystemWindows
+            this,
+            fullScreen,
+            hideSystemBars,
+            fitsSystemWindows
         )
     }
 }
 
 fun Activity.setFullScreen(
+    rootView: View,
     fullScreen: Boolean = true,
     hideSystemBars: Boolean = true,
-    fitsSystemWindows: Boolean = true,
-    rootView: View
+    fitsSystemWindows: Boolean = true
 ) {
     rootView.viewTreeObserver?.addOnWindowFocusChangeListener { hasFocus ->
         if (hasFocus) {


### PR DESCRIPTION
I've changed the argument order in the `Activity.setFullScreen` extension function since the argument without a default value should be the first one.
I've also wanted to add a method to the `ViewNode` for setting the `View` from code but decided to leave a TODO comment since the `ViewRenderable.Builder` can be used directly to do that and it will be easier to add new methods after we migrate to the new way of creating renderables.