### PR TITLE
Make pan gesture configurable

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/interaction/GestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/interaction/GestureDetector.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.sceneview.interaction
+
+import android.view.MotionEvent
+import android.view.View
+import com.google.android.filament.utils.Float2
+import com.google.android.filament.utils.Manipulator
+import com.google.android.filament.utils.distance
+import com.google.android.filament.utils.mix
+
+/**
+ * Responds to Android touch events and manages a camera manipulator.
+ * Supports one-touch orbit, two-touch pan, and pinch-to-zoom.
+ *
+ * Copied from filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
+ */
+class GestureDetector(
+    private val view: View,
+    private val manipulator: Manipulator
+) {
+    private enum class Gesture { NONE, ORBIT, PAN, ZOOM }
+
+    // Simplified memento of MotionEvent, minimal but sufficient for our purposes.
+    private data class TouchPair(var pt0: Float2, var pt1: Float2, var count: Int) {
+        constructor() : this(Float2(0f), Float2(0f), 0)
+        constructor(me: MotionEvent, height: Int) : this() {
+            if (me.pointerCount >= 1) {
+                this.pt0 = Float2(me.getX(0), height - me.getY(0))
+                this.pt1 = this.pt0
+                this.count++
+            }
+            if (me.pointerCount >= 2) {
+                this.pt1 = Float2(me.getX(1), height - me.getY(1))
+                this.count++
+            }
+        }
+
+        val separation get() = distance(pt0, pt1)
+        val midpoint get() = mix(pt0, pt1, 0.5f)
+        val x: Int get() = midpoint.x.toInt()
+        val y: Int get() = midpoint.y.toInt()
+    }
+
+    private var currentGesture = Gesture.NONE
+    private var previousTouch = TouchPair()
+    private val tentativePanEvents = ArrayList<TouchPair>()
+    private val tentativeOrbitEvents = ArrayList<TouchPair>()
+    private val tentativeZoomEvents = ArrayList<TouchPair>()
+
+    private val kGestureConfidenceCount = 2
+    private val kPanConfidenceDistance = 10
+    private val kZoomConfidenceDistance = 10
+    private val kZoomSpeed = 1f / 10f
+
+    var panSupported: Boolean = true
+
+    fun onTouchEvent(event: MotionEvent) {
+        val touch = TouchPair(event, view.height)
+        when (event.actionMasked) {
+            MotionEvent.ACTION_MOVE -> {
+
+                // CANCEL GESTURE DUE TO UNEXPECTED POINTER COUNT
+
+                if ((event.pointerCount != 1 && currentGesture == Gesture.ORBIT) ||
+                    (event.pointerCount != 2 && currentGesture == Gesture.PAN) ||
+                    (event.pointerCount != 2 && currentGesture == Gesture.ZOOM)
+                ) {
+                    endGesture()
+                    return
+                }
+
+                // UPDATE EXISTING GESTURE
+
+                if (currentGesture == Gesture.ZOOM) {
+                    val d0 = previousTouch.separation
+                    val d1 = touch.separation
+                    manipulator.scroll(touch.x, touch.y, (d0 - d1) * kZoomSpeed)
+                    previousTouch = touch
+                    return
+                }
+
+                if (currentGesture != Gesture.NONE) {
+                    manipulator.grabUpdate(touch.x, touch.y)
+                    return
+                }
+
+                // DETECT NEW GESTURE
+
+                if (event.pointerCount == 1) {
+                    tentativeOrbitEvents.add(touch)
+                }
+
+                if (event.pointerCount == 2) {
+                    tentativePanEvents.add(touch)
+                    tentativeZoomEvents.add(touch)
+                }
+
+                if (isOrbitGesture()) {
+                    manipulator.grabBegin(touch.x, touch.y, false)
+                    currentGesture = Gesture.ORBIT
+                    return
+                }
+
+                if (isZoomGesture()) {
+                    currentGesture = Gesture.ZOOM
+                    previousTouch = touch
+                    return
+                }
+
+                if (isPanGesture()) {
+                    manipulator.grabBegin(touch.x, touch.y, true)
+                    currentGesture = Gesture.PAN
+                    return
+                }
+            }
+            MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_UP -> {
+                endGesture()
+            }
+        }
+    }
+
+    private fun endGesture() {
+        tentativePanEvents.clear()
+        tentativeOrbitEvents.clear()
+        tentativeZoomEvents.clear()
+        currentGesture = Gesture.NONE
+        manipulator.grabEnd()
+    }
+
+    private fun isOrbitGesture(): Boolean {
+        return tentativeOrbitEvents.size > kGestureConfidenceCount
+    }
+
+    private fun isPanGesture(): Boolean {
+        if (!panSupported || tentativePanEvents.size <= kGestureConfidenceCount) {
+            return false
+        }
+        val oldest = tentativePanEvents.first().midpoint
+        val newest = tentativePanEvents.last().midpoint
+        return distance(oldest, newest) > kPanConfidenceDistance
+    }
+
+    private fun isZoomGesture(): Boolean {
+        if (tentativeZoomEvents.size <= kGestureConfidenceCount) {
+            return false
+        }
+        val oldest = tentativeZoomEvents.first().separation
+        val newest = tentativeZoomEvents.last().separation
+        return kotlin.math.abs(newest - oldest) > kZoomConfidenceDistance
+    }
+}

--- a/sceneview/src/main/java/io/github/sceneview/interaction/GestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/interaction/GestureDetector.kt
@@ -67,7 +67,7 @@ class GestureDetector(
     private val kZoomConfidenceDistance = 10
     private val kZoomSpeed = 1f / 10f
 
-    var panSupported: Boolean = true
+    var isPanEnabled: Boolean = true
 
     fun onTouchEvent(event: MotionEvent) {
         val touch = TouchPair(event, view.height)
@@ -147,7 +147,7 @@ class GestureDetector(
     }
 
     private fun isPanGesture(): Boolean {
-        if (!panSupported || tentativePanEvents.size <= kGestureConfidenceCount) {
+        if (!isPanEnabled || tentativePanEvents.size <= kGestureConfidenceCount) {
             return false
         }
         val oldest = tentativePanEvents.first().midpoint

--- a/sceneview/src/main/java/io/github/sceneview/interaction/SceneGestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/interaction/SceneGestureDetector.kt
@@ -11,7 +11,7 @@ import io.github.sceneview.math.Transform
 import io.github.sceneview.math.toFloat3
 import io.github.sceneview.node.Node
 
-typealias FilamentGestureDetector = com.google.android.filament.utils.GestureDetector
+typealias FilamentGestureDetector = io.github.sceneview.interaction.GestureDetector
 
 /**
  * ### Responds to Android touch events with listeners and/or camera manipulator


### PR DESCRIPTION
**What does the change do?**

- Increase confidence needed to start pan gestures
- Allow users to deactivate pan gestures completely

The problem to solve here is that when the user tries to zoom it's sometimes mistaken for a pan gesture and triggers strafing in ORBIT mode. This moves the user away from the model he/she is looking at. Often the model is not visible at all anymore. 
Also when looking at a 3D model the option to strafe might be not needed at all and so it's possible to deactivate the gesture completely.

I copied the GestureDetector class from Filament to our code base as the Filament team threat it as sample code and is not accepting feature requests for it.  