### PR TITLE
Inverted y coordinate for picking

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -486,11 +486,11 @@ open class SceneView @JvmOverloads constructor(
     open class DefaultSceneGestureListener(val sceneView: SceneView) :
         SceneGestureDetector.OnSceneGestureListener {
         override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-            sceneView.renderer.filamentView.pick(
-                e.x.roundToInt(),
-                e.y.roundToInt(),
-                sceneView.pickingHandler
-            ) { pickResult ->
+            // Invert the y coordinate since its origin is at the bottom
+            val x = e.x.roundToInt()
+            val y = sceneView.height - 1 - e.y.roundToInt()
+
+            sceneView.renderer.filamentView.pick(x, y, sceneView.pickingHandler) { pickResult ->
                 val pickedEntity = pickResult.renderable
                 val selectedNode = sceneView.allChildren
                     .mapNotNull { it as? ModelNode }


### PR DESCRIPTION
According to the Filament documentation the `y` coordinate has its origin at the bottom of the viewport: https://github.com/google/filament/blob/5f52afdc08813c346bcfe52313881803746c437f/android/filament-android/src/main/java/com/google/android/filament/View.java#L1046
That is why it was hard to pick small objects :tada: 