### PR TITLE
Fixed synchronization of 3D scene state and camera frames using Frame.getCameraTextureName

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
@@ -251,9 +251,7 @@ class ArCameraStream(
             cameraTextures?.forEach { it.destroy() }
             cameraTextures = textures
         }
-        cameraTexture = cameraTexture?.let {
-            cameraTextures.getOrNull(cameraTextures.indexOf(it) + 1)
-        } ?: cameraTextures.first()
+        cameraTexture = cameraTextures.getOrNull(cameraTextureIds.indexOf(frame.cameraTextureName))
 
         // Recalculate camera Uvs if necessary.
         if (transformedUvCoordinates == null || frame.hasDisplayGeometryChanged()) {


### PR DESCRIPTION
The solution was suggested here: https://github.com/google/filament/issues/5683