### PR TITLE
Catch NotTrackingException when calling HitResult.createAnchor

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/ArFrame.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/ArFrame.kt
@@ -1,9 +1,11 @@
 package io.github.sceneview.ar.arcore
 
+import android.util.Log
 import android.view.MotionEvent
 import com.google.ar.core.*
 import io.github.sceneview.math.Position
 import io.github.sceneview.utils.FrameTime
+import io.github.sceneview.utils.TAG
 import kotlin.math.abs
 
 /**
@@ -201,14 +203,21 @@ data class ArFrame(
         depth: Boolean = session.depthEnabled,
         instant: Boolean = session.instantPlacementEnabled,
         approximateDistance: Float = session.approximateDistance
-    ): Anchor? = hitTest(
-        xPx = xPx,
-        yPx = yPx,
-        plane = plane,
-        depth = depth,
-        instant = instant,
-        approximateDistance = approximateDistance
-    )?.createAnchor()
+    ): Anchor? {
+        return try {
+            hitTest(
+                xPx = xPx,
+                yPx = yPx,
+                plane = plane,
+                depth = depth,
+                instant = instant,
+                approximateDistance = approximateDistance
+            )?.createAnchor()
+        } catch (exception: Exception) {
+            Log.e(TAG, "Can't create anchor: $exception")
+            null
+        }
+    }
 
     /**
      * ### Retrieve the frame tracked Planes

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/ArModelNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/ArModelNode.kt
@@ -1,6 +1,7 @@
 package io.github.sceneview.ar.node
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.Lifecycle
 import com.google.ar.core.*
 import com.google.ar.core.Config.PlaneFindingMode
@@ -13,6 +14,7 @@ import io.github.sceneview.gesture.NodeMotionEvent
 import io.github.sceneview.math.Position
 import io.github.sceneview.model.Model
 import io.github.sceneview.node.Node
+import io.github.sceneview.utils.TAG
 
 /**
  * ### AR positioned 3D model node
@@ -322,8 +324,12 @@ open class ArModelNode : ArNode {
         super.onMoveEnd(detector, e)
 
         if (isPositionEditable && currentEditingTransform == ::position) {
-            anchor = lastTrackingHitResult?.createAnchor()
-            currentEditingTransform = null
+            try {
+                anchor = lastTrackingHitResult?.createAnchor()
+                currentEditingTransform = null
+            } catch (exception: Exception) {
+                Log.e(TAG, "Can't create anchor: $exception")
+            }
         }
     }
 
@@ -377,9 +383,15 @@ open class ArModelNode : ArNode {
      */
     open fun createAnchor(): Anchor? {
         // lastTrackingHitResult might become not tracking anymore during time
-        val hitResult =
-            lastTrackingHitResult?.takeIf { it.isTracking } ?: hitTest()?.takeIf { it.isTracking }
-        return hitResult?.createAnchor()
+        return try {
+            val hitResult =
+                lastTrackingHitResult?.takeIf { it.isTracking }
+                    ?: hitTest()?.takeIf { it.isTracking }
+            hitResult?.createAnchor()
+        } catch (exception: Exception) {
+            Log.e(TAG, "Can't create anchor: $exception")
+            null
+        }
     }
 
     override fun clone() = copy(ArModelNode())


### PR DESCRIPTION
Hello together,
Great project! I like it very much and use it in a current project.

During testing I found that there is the `com.google.ar.core.exceptions.NotTrackingException` that can occur if `createAnchor()` is called on a `HitResult` that is in a scene that is not tracking.

It can be reproduced in the `sample-ar-model-viewer` with the following steps:
1. Establish tracking and place the robot.
2. Drag the robot and break the tracking.
3. If you then end the drag in the right moment it produces the appended stack-trace.

(I broke the tracking either through blocking the camera with one hand, or by locking the phone and unlocking it again and start dragging right away before the tracking is established)

I would suggest wrapping those calls to the `createAnchor()` in a `try catch` mostly because the locations where this happens return an `Anchor?` anyway, so a try catch does not break any other code but keeps the scene from crashing.

(Tested on Pixel 3a with Android 12)

2022-09-02 14:45:00.639 18540-18540/io.github.sceneview.sample.armodelviewer E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.github.sceneview.sample.armodelviewer, PID: 18540
    com.google.ar.core.exceptions.NotTrackingException
        at java.lang.reflect.Constructor.newInstance0(Native Method)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
        at com.google.ar.core.Session.throwExceptionFromArStatus(Session.java:14)
        at com.google.ar.core.HitResult.nativeCreateAnchor(Native Method)
        at com.google.ar.core.HitResult.createAnchor(HitResult.java:1)
        at io.github.sceneview.ar.node.ArModelNode.onMoveEnd(ArModelNode.kt:325)
        at io.github.sceneview.gesture.GestureDetector$moveGestureDetector$1.onMoveEnd(GestureDetector.kt:257)
        at io.github.sceneview.gesture.MoveGestureDetector.onTouchEvent(MoveGestureDetector.kt:160)
        at io.github.sceneview.gesture.GestureDetector.onTouchEvent(GestureDetector.kt:328)
        at io.github.sceneview.SceneView.onTouchEvent(SceneView.kt:546)
        at android.view.View.dispatchTouchEvent(View.java:14599)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3120)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2801)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3120)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2801)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3120)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2801)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3120)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2801)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3120)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2801)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3120)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2801)
        at com.android.internal.policy.DecorView.superDispatchTouchEvent(DecorView.java:498)
        at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent(PhoneWindow.java:1890)
        at android.app.Activity.dispatchTouchEvent(Activity.java:4199)
        at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent(WindowCallbackWrapper.java:69)
        at com.android.internal.policy.DecorView.dispatchTouchEvent(DecorView.java:456)
        at android.view.View.dispatchPointerEvent(View.java:14858)
        at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:6446)
        at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:6247)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5725)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5782)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5748)
        at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:5913)
        at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5756)
        at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:5970)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5729)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5782)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5748)
        at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5756)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5729)
        at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:8696)
        at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:8647)
        at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:8616)
        at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:8819)
        at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:259)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:335)
        at android.os.Looper.loopOnce(Looper.java:161)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7870)
2022-09-02 14:45:00.639 18540-18540/io.github.sceneview.sample.armodelviewer E/AndroidRuntime:     at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at `com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
