### PR TITLE
Fix crash on rendered frame copy used by SceneView recorder

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -508,6 +508,11 @@ open class SceneView @JvmOverloads constructor(
         // Render the scene, unless the renderer wants to skip the frame.
         if (renderer.beginFrame(swapChain!!, frameTime.nanoseconds)) {
             renderer.render(view)
+
+            lifecycle.dispatchEvent<RendererLifecycleObserver> {
+                onRenderFrame()
+            }
+
             renderer.endFrame()
         }
     }
@@ -632,9 +637,6 @@ open class SceneView @JvmOverloads constructor(
     }
 
     fun startRecording(mediaRecorder: MediaRecorder) {
-        mediaRecorder.apply {
-            setVideoSource(MediaRecorder.VideoSource.SURFACE)
-        }
         mediaRecorder.prepare()
         mediaRecorder.start()
         surfaceCopier.startMirroring(mediaRecorder.surface)
@@ -644,7 +646,6 @@ open class SceneView @JvmOverloads constructor(
         surfaceCopier.stopMirroring(mediaRecorder.surface)
         mediaRecorder.stop()
         mediaRecorder.reset()
-        mediaRecorder.surface.release()
     }
 
     /**
@@ -750,5 +751,10 @@ interface SceneLifecycleObserver : DefaultLifecycleObserver {
     }
 
     fun onFrame(frameTime: FrameTime) {
+    }
+}
+
+interface RendererLifecycleObserver : DefaultLifecycleObserver {
+    fun onRenderFrame() {
     }
 }

--- a/sceneview/src/main/java/io/github/sceneview/utils/SurfaceCopier.kt
+++ b/sceneview/src/main/java/io/github/sceneview/utils/SurfaceCopier.kt
@@ -5,6 +5,7 @@ import com.google.android.filament.Renderer
 import com.google.android.filament.SwapChain
 import com.google.android.filament.Viewport
 import io.github.sceneview.Filament
+import io.github.sceneview.RendererLifecycleObserver
 import io.github.sceneview.SceneLifecycle
 import io.github.sceneview.SceneLifecycleObserver
 
@@ -13,7 +14,7 @@ import io.github.sceneview.SceneLifecycleObserver
  */
 class SurfaceCopier(
     private val lifecycle: SceneLifecycle
-) : SceneLifecycleObserver {
+) : RendererLifecycleObserver {
 
     data class SurfaceMirror(
         val surface: Surface,
@@ -29,8 +30,8 @@ class SurfaceCopier(
         lifecycle.addObserver(this)
     }
 
-    override fun onFrame(frameTime: FrameTime) {
-        super.onFrame(frameTime)
+    override fun onRenderFrame() {
+        super.onRenderFrame()
 
         surfaceMirrors.forEach { mirror ->
             if (mirror.swapChain != null) {


### PR DESCRIPTION
In current implementation `SurfaceCopier` makes copy using `SceneLifecycleObserver.onFrame()`, which is wrong and causing instant crash.

Considering Filament documentation `copyFrame() should be called after a frame is rendered using render but before endFrame is called.`