### PR TITLE
Made isSelected open in Node so that subclasses can override it

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/nodes/Node.kt
+++ b/sceneview/src/main/java/io/github/sceneview/nodes/Node.kt
@@ -121,7 +121,7 @@ open class Node(
             updateSelectionVisualizer()
         }
 
-    var isSelected = false
+    open var isSelected = false
         internal set(value) {
             field = value
             updateSelectionVisualizer()


### PR DESCRIPTION
By overriding the setter, subclasses can add custom behavior when the node is selected or deselected.