### PR TITLE
Update depth occlusion

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
@@ -277,12 +277,12 @@ class ArCameraStream(
         when (sceneView.depthMode) {
             Config.DepthMode.AUTOMATIC -> {
                 runCatching {
-                    frame.acquireDepthImage()
+                    frame.acquireDepthImage16Bits()
                 }.getOrNull()
             }
             Config.DepthMode.RAW_DEPTH_ONLY -> {
                 runCatching {
-                    frame.acquireRawDepthImage()
+                    frame.acquireRawDepthImage16Bits()
                 }.getOrNull()
             }
             else -> null


### PR DESCRIPTION
Update of two functions to use the update of ArCore in may 2022 for the depth occlusion API: https://developers.google.com/ar/develop/depth/changes