### PR TITLE
debug lifecycle destroy crash

### DIFF
--- a/samples/ar-cursor-placement/src/main/AndroidManifest.xml
+++ b/samples/ar-cursor-placement/src/main/AndroidManifest.xml
@@ -7,15 +7,24 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.SceneViewSample">
         <activity
+            android:name=".MainActivity"
+            android:configChanges="orientation|screenSize"
+            android:exported="true"
+            android:screenOrientation="locked">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".Activity"
             android:configChanges="orientation|screenSize"
             android:exported="true"
             android:label="@string/app_name"
             android:screenOrientation="locked">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+
         </activity>
     </application>
+
 </manifest>

--- a/samples/ar-cursor-placement/src/main/java/io/github/sceneview/sample/arcursorplacement/MainActivity.kt
+++ b/samples/ar-cursor-placement/src/main/java/io/github/sceneview/sample/arcursorplacement/MainActivity.kt
@@ -1,0 +1,18 @@
+package io.github.sceneview.sample.arcursorplacement
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.Button
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        val button = findViewById<Button>(R.id.launch_button)
+        button.setOnClickListener {
+            val intent = Intent(this, Activity::class.java)
+            startActivity(intent)
+        }
+    }
+}

--- a/samples/ar-cursor-placement/src/main/res/layout/activity_main.xml
+++ b/samples/ar-cursor-placement/src/main/res/layout/activity_main.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <Button
+        android:id="@+id/launch_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="launch AR"
+        android:layout_gravity="center"
+        />
+
+</FrameLayout>

--- a/sceneview/src/main/java/io/github/sceneview/model/GLBLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/model/GLBLoader.kt
@@ -3,6 +3,7 @@ package io.github.sceneview.model
 import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
+import com.gorisse.thomas.lifecycle.doOnDestroy
 import com.gorisse.thomas.lifecycle.observe
 import io.github.sceneview.Filament.assetLoader
 import io.github.sceneview.Filament.resourceLoader
@@ -66,10 +67,10 @@ object GLBLoader {
                 it.setScreenSpaceContactShadows(true)
             }
 
-            lifecycle?.observe(onDestroy = {
+            lifecycle?.doOnDestroy {
                 // Prevent double destroy in case of manually destroyed
                 runCatching { asset.destroy() }
-            })
+            }
         }
     }
 


### PR DESCRIPTION
Essentially, the destroy that crashes the app is the first call to asset.destroy() after filament.destroy() has already been called. The _assetLoader is set to null, so it is reinstantiated from the call to Filament.assetLoader in asset.destroy(), that works fine, but the subsequent call to AssetLoader.nDestroyAsset(mNativeObject, asset.getNativeObject()); seems to crash the app.

https://github.com/sameerjj/sceneview-android/tree/sameer-debug-destroy-crash

this PR has a MainActivity in sample/ar-cursor-placement which allows for easy reproduction of the issue.