### PR TITLE
ensure surfaceMirror onFrame is called properly during render cycle

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -508,6 +508,7 @@ open class SceneView @JvmOverloads constructor(
         // Render the scene, unless the renderer wants to skip the frame.
         if (renderer.beginFrame(swapChain!!, frameTime.nanoseconds)) {
             renderer.render(view)
+            surfaceMirrorer.onFrame()
             renderer.endFrame()
         }
     }

--- a/sceneview/src/main/java/io/github/sceneview/utils/SurfaceMirrorer.kt
+++ b/sceneview/src/main/java/io/github/sceneview/utils/SurfaceMirrorer.kt
@@ -13,7 +13,7 @@ import io.github.sceneview.SceneLifecycleObserver
  */
 class SurfaceMirrorer(
     private val lifecycle: SceneLifecycle
-) : SceneLifecycleObserver {
+) {
 
     data class SurfaceMirror(
         val surface: Surface,
@@ -25,12 +25,7 @@ class SurfaceMirrorer(
 
     private val sceneView get() = lifecycle.sceneView
 
-    init {
-        lifecycle.addObserver(this)
-    }
-
-    override fun onFrame(frameTime: FrameTime) {
-        super.onFrame(frameTime)
+    fun onFrame() {
 
         surfaceMirrors.forEach { mirror ->
             if (mirror.swapChain != null) {


### PR DESCRIPTION
`sceneView.renderer.copyFrame` can only be called in a very specific part of the rendering cycle in order to work and not crash the app. 

Remove `SceneLifecycleObserver` and call this manually in the `SceneView`