### PR TITLE
Fixes crash when model doesn't have an animation.

### DIFF
--- a/samples/model-viewer/src/main/java/io/github/sceneview/sample/modelviewer/MainFragment.kt
+++ b/samples/model-viewer/src/main/java/io/github/sceneview/sample/modelviewer/MainFragment.kt
@@ -35,7 +35,11 @@ class MainFragment : Fragment(R.layout.fragment_main) {
                 intensity(50_000f)
             }
 
-            val model = sceneView.modelLoader.loadModel("models/MaterialSuite.glb")!!
+            // Animated Model
+//            val model = sceneView.modelLoader.loadModel("models/MaterialSuite.glb")!!
+            // No Animation Model
+            val model = sceneView.modelLoader.loadModel("models/BoomBox.glb")!!
+
             val modelNode = ModelNode(sceneView, model).apply {
                 transform(
                     position = Position(z = -4.0f),

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/nodes/ModelNode.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/nodes/ModelNode.kt
@@ -151,6 +151,8 @@ open class ModelNode private constructor(
      * @see animationCount
      */
     fun playAnimation(animationIndex: Int = 0, loop: Boolean = true) {
+        if (animationCount == 0) return
+
         if (animationIndex <= animationCount) {
             playingAnimations[animationIndex] = PlayingAnimation(loop = loop)
         }


### PR DESCRIPTION
Fixes crash when a model doesn't have an animation and playAnimation() is called on it in a Sceneview. See https://github.com/SceneView/sceneview-android/issues/237

Note: Changes in MainFragment.kt and the BoomBox.glb are only there for testing. They will be removed before merging.

To test:
Run the sample app samples.model-viewer with the BoomBox.glb which is unanimated. It should not crash.
Uncomment modelviewer/MainFragment.kt line 39 and comment out modelviewer/MainFragment.kt line 41.
Run the sample app again. The MaterialSuite.glb should run it's animation.