### PR TITLE
Fixed Recording bug

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -497,16 +497,16 @@ open class SceneView @JvmOverloads constructor(
             }
         }
 
-        lifecycle.dispatchEvent<SceneLifecycleObserver> {
-            onFrame(frameTime)
-        }
-        onFrame?.invoke(frameTime)
 
         transformManager.commitLocalTransformTransaction()
+        onFrame?.invoke(frameTime)
 
         // Render the scene, unless the renderer wants to skip the frame.
         if (renderer.beginFrame(swapChain!!, frameTime.nanoseconds)) {
             renderer.render(view)
+            lifecycle.dispatchEvent<SceneLifecycleObserver> {
+                onFrame(frameTime)
+            }
             renderer.endFrame()
         }
     }

--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -504,10 +504,10 @@ open class SceneView @JvmOverloads constructor(
 
         // Render the scene, unless the renderer wants to skip the frame.
         if (renderer.beginFrame(swapChain!!, frameTime.nanoseconds)) {
-            renderer.render(view)
             lifecycle.dispatchEvent<SceneLifecycleObserver> {
                 onFrame(frameTime)
             }
+            renderer.render(view)
             renderer.endFrame()
         }
     }

--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -498,8 +498,9 @@ open class SceneView @JvmOverloads constructor(
         }
 
 
-        transformManager.commitLocalTransformTransaction()
         onFrame?.invoke(frameTime)
+
+        transformManager.commitLocalTransformTransaction()
 
         // Render the scene, unless the renderer wants to skip the frame.
         if (renderer.beginFrame(swapChain!!, frameTime.nanoseconds)) {


### PR DESCRIPTION
Currently, When we call startMirroring function it causes the app to crash with an a fatal error:
`Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8 in tid 11929 (.recordingarpoc), pid 11929 (.recordingarpoc)`

This issue can be verified by trying the sample app [ar-cursor-placement](https://github.com/SceneView/sceneview-android/tree/main/samples/ar-cursor-placement)

I've fixed the above issue 