### PR TITLE
Fix for rendering semi-transparent models and plane renderer

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
@@ -172,7 +172,6 @@ class ArCameraStream(
     val renderable: Renderable = RenderableManager.Builder(4)
         .castShadows(false)
         .receiveShadows(false)
-        .channel(0)
         // Always draw the camera feed last to avoid overdraw
         .culling(false)
         .priority(priority)

--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ArCameraStream.kt
@@ -172,8 +172,7 @@ class ArCameraStream(
     val renderable: Renderable = RenderableManager.Builder(4)
         .castShadows(false)
         .receiveShadows(false)
-        // Use different channel from other ones
-        .channel(3)
+        .channel(0)
         // Always draw the camera feed last to avoid overdraw
         .culling(false)
         .priority(priority)


### PR DESCRIPTION
Configure the `renderable` to use only 1 channel.
```kotlin
.channel(0)
```

**Note** Previously I reduced the number of primitives to 1 from 4, but I double checked that it has no effect. So the number of primitives I set back to 4.