### PR TITLE
Update onMoveEnd to use anchor() to fix crash.

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/ArModelNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/ArModelNode.kt
@@ -330,7 +330,7 @@ open class ArModelNode : ArNode {
         super.onMoveEnd(detector, e)
 
         if (isPositionEditable && currentEditingTransform == ::position) {
-            anchor = lastTrackingHitResult?.createAnchor()
+            anchor = anchor()
             currentEditingTransform = null
         }
     }


### PR DESCRIPTION
This PR addresses the issue in #231 . Thanks @hshapley for the fix idea.

I tested this fix on a Samsung S20 and Pixel 3. The `samples.ar-model-viewer` app no longer crashes. I've attached an `after1.mp4` to show the fix. 

It shows two things, in some instances the model will move to a slightly different location than where I tried to drop it. Also, when there are no trackables in view, the message "Can't find anything. Aim device at a surface with more texture or color." will appear. Both are expected and preferred outcomes.

After fix:

https://user-images.githubusercontent.com/10900996/235731193-45b59d03-2cae-49f9-9590-8f5f07183687.mp4

Before fix:

https://user-images.githubusercontent.com/10900996/235731237-664c266e-b681-45f2-a477-bec57c3fca70.mp4


