### PR TITLE
Fixed Geometries

### DIFF
--- a/samples/model-viewer/src/main/java/io/github/sceneview/sample/modelviewer/MainFragment.kt
+++ b/samples/model-viewer/src/main/java/io/github/sceneview/sample/modelviewer/MainFragment.kt
@@ -12,6 +12,7 @@ import io.github.sceneview.loaders.loadHdrSkybox
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
 import io.github.sceneview.nodes.ModelNode
+import io.github.sceneview.nodes.ViewNode
 
 class MainFragment : Fragment(R.layout.fragment_main) {
 
@@ -43,10 +44,21 @@ class MainFragment : Fragment(R.layout.fragment_main) {
                 )
                 scaleToUnitsCube(2.0f)
                 // TODO: Fix centerOrigin
-//                centerOrigin(Position(x=-1.0f, y=-1.0f))
+                //  centerOrigin(Position(x=-1.0f, y=-1.0f))
                 playAnimation()
             }
             sceneView.addChildNode(modelNode)
+
+            val viewNode = ViewNode(
+                sceneView = sceneView,
+                viewResourceId = R.layout.view_node_layout
+            ).apply {
+                transform(
+                    position = Position(z = -4f),
+                    rotation = Rotation()
+                )
+            }
+            sceneView.addChildNode(viewNode)
 
             loadingView.isGone = true
         }

--- a/samples/model-viewer/src/main/res/layout/view_node_layout.xml
+++ b/samples/model-viewer/src/main/res/layout/view_node_layout.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="50dp"
+    android:background="@color/sceneview"
+    android:gravity="center"
+    android:text="@string/hello_view_node" />

--- a/samples/model-viewer/src/main/res/values/strings.xml
+++ b/samples/model-viewer/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">3D Model Viewer</string>
+    <string name="hello_view_node">Hello ViewNode</string>
 </resources>

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Cube.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Cube.kt
@@ -25,7 +25,7 @@ class Cube private constructor(
      * @param center the center of the constructed cube
      */
     class Builder(val size: Size = Size(2.0f), val center: Position = Position(0.0f)) :
-        BaseBuilder<Cube>(
+        BaseGeometryBuilder<Cube>(
             vertices = mutableListOf<Vertex>().apply {
                 val extents = size * 0.5f
                 val p0 = center + Size(-extents.x, -extents.y, extents.z)

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Cylinder.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Cylinder.kt
@@ -42,7 +42,7 @@ class Cylinder(
         val height: Float = 2.0f,
         val center: Position = Position(0.0f),
         val sideCount: Int = 24
-    ) : BaseBuilder<Cylinder>(
+    ) : BaseGeometryBuilder<Cylinder>(
         vertices = mutableListOf<Geometry.Vertex>().apply {
             val halfHeight = height / 2
             val thetaIncrement = TWO_PI / sideCount

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Geometry.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Geometry.kt
@@ -153,8 +153,8 @@ open class Geometry(
             }.build(engine)
 
             return build(vertexBuffer, indexBuffer).apply {
-                setBufferVertices(engine, vertices)
-                setBufferIndices(engine, submeshes)
+                setBufferVertices(engine, this@BaseBuilder.vertices)
+                setBufferIndices(engine, this@BaseBuilder.submeshes)
             }
         }
 

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Geometry.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Geometry.kt
@@ -75,94 +75,11 @@ open class Geometry(
     open class Builder(
         vertices: List<Vertex> = listOf(),
         submeshes: List<Submesh> = listOf()
-    ) : BaseBuilder<Geometry>(vertices, submeshes) {
+    ) : BaseGeometryBuilder<Geometry>(vertices, submeshes) {
         override fun build(
             vertexBuffer: VertexBuffer,
             indexBuffer: IndexBuffer
         ) = Geometry(vertexBuffer, indexBuffer)
-    }
-
-    abstract class BaseBuilder<T : Geometry> internal constructor(
-        var vertices: List<Vertex> = listOf(),
-        var submeshes: List<Submesh> = listOf()
-    ) {
-
-        fun vertices(vertices: List<Vertex>) = apply { this.vertices = vertices }
-        fun submeshes(submeshes: List<Submesh>) = apply { this.submeshes = submeshes }
-
-        open fun build(engine: Engine): T {
-            val vertexBuffer = VertexBuffer.Builder().apply {
-                bufferCount(
-                    1 + // Position is never null
-                            (if (vertices.hasNormals) 1 else 0) +
-                            (if (vertices.hasUvCoordinates) 1 else 0) +
-                            (if (vertices.hasColors) 1 else 0)
-                )
-                vertexCount(vertices.size)
-
-                // Position Attribute
-                var bufferIndex = 0
-                attribute(
-                    VertexBuffer.VertexAttribute.POSITION,
-                    bufferIndex,
-                    VertexBuffer.AttributeType.FLOAT3,
-                    0,
-                    kPositionSize * Float.SIZE_BYTES
-                )
-                // Tangents Attribute
-                if (vertices.hasNormals) {
-                    bufferIndex++
-                    attribute(
-                        VertexBuffer.VertexAttribute.TANGENTS,
-                        bufferIndex,
-                        VertexBuffer.AttributeType.FLOAT4,
-                        0,
-                        kTangentSize * Float.SIZE_BYTES
-                    )
-                    normalized(VertexBuffer.VertexAttribute.TANGENTS)
-                }
-                // Uv Attribute
-                if (vertices.hasUvCoordinates) {
-                    bufferIndex++
-                    attribute(
-                        VertexBuffer.VertexAttribute.UV0,
-                        bufferIndex,
-                        VertexBuffer.AttributeType.FLOAT2,
-                        0,
-                        kUVSize * Float.SIZE_BYTES
-                    )
-                }
-                // Color Attribute
-                if (vertices.hasColors) {
-                    bufferIndex++
-                    attribute(
-                        VertexBuffer.VertexAttribute.COLOR,
-                        bufferIndex,
-                        VertexBuffer.AttributeType.FLOAT4,
-                        0,
-                        kColorSize * Float.SIZE_BYTES
-                    )
-                    normalized(VertexBuffer.VertexAttribute.COLOR)
-                }
-            }.build(engine)
-
-            // Determine how many indices there are
-            val indexBuffer = IndexBuffer.Builder().apply {
-                indexCount(submeshes.sumOf { it.triangleIndices.size })
-                    .bufferType(IndexBuffer.Builder.IndexType.UINT)
-            }.build(engine)
-
-            return build(vertexBuffer, indexBuffer).apply {
-                setBufferVertices(engine, this@BaseBuilder.vertices)
-                setBufferIndices(engine, this@BaseBuilder.submeshes)
-            }
-        }
-
-        fun build(sceneView: SceneView) = build(sceneView.engine).also {
-            sceneView.geometries += it
-        }
-
-        internal abstract fun build(vertexBuffer: VertexBuffer, indexBuffer: IndexBuffer): T
     }
 
     fun setBufferVertices(engine: Engine, vertices: List<Vertex>) {
@@ -249,6 +166,89 @@ open class Geometry(
             }
         }
     }
+}
+
+abstract class BaseGeometryBuilder<T : Geometry> internal constructor(
+    var vertices: List<Geometry.Vertex> = listOf(),
+    var submeshes: List<Geometry.Submesh> = listOf()
+) {
+
+    fun vertices(vertices: List<Geometry.Vertex>) = apply { this.vertices = vertices }
+    fun submeshes(submeshes: List<Geometry.Submesh>) = apply { this.submeshes = submeshes }
+
+    open fun build(engine: Engine): T {
+        val vertexBuffer = VertexBuffer.Builder().apply {
+            bufferCount(
+                1 + // Position is never null
+                        (if (vertices.hasNormals) 1 else 0) +
+                        (if (vertices.hasUvCoordinates) 1 else 0) +
+                        (if (vertices.hasColors) 1 else 0)
+            )
+            vertexCount(vertices.size)
+
+            // Position Attribute
+            var bufferIndex = 0
+            attribute(
+                VertexBuffer.VertexAttribute.POSITION,
+                bufferIndex,
+                VertexBuffer.AttributeType.FLOAT3,
+                0,
+                kPositionSize * Float.SIZE_BYTES
+            )
+            // Tangents Attribute
+            if (vertices.hasNormals) {
+                bufferIndex++
+                attribute(
+                    VertexBuffer.VertexAttribute.TANGENTS,
+                    bufferIndex,
+                    VertexBuffer.AttributeType.FLOAT4,
+                    0,
+                    kTangentSize * Float.SIZE_BYTES
+                )
+                normalized(VertexBuffer.VertexAttribute.TANGENTS)
+            }
+            // Uv Attribute
+            if (vertices.hasUvCoordinates) {
+                bufferIndex++
+                attribute(
+                    VertexBuffer.VertexAttribute.UV0,
+                    bufferIndex,
+                    VertexBuffer.AttributeType.FLOAT2,
+                    0,
+                    kUVSize * Float.SIZE_BYTES
+                )
+            }
+            // Color Attribute
+            if (vertices.hasColors) {
+                bufferIndex++
+                attribute(
+                    VertexBuffer.VertexAttribute.COLOR,
+                    bufferIndex,
+                    VertexBuffer.AttributeType.FLOAT4,
+                    0,
+                    kColorSize * Float.SIZE_BYTES
+                )
+                normalized(VertexBuffer.VertexAttribute.COLOR)
+            }
+        }.build(engine)
+
+        // Determine how many indices there are
+        val indexBuffer = IndexBuffer.Builder().apply {
+            indexCount(submeshes.sumOf { it.triangleIndices.size })
+                .bufferType(IndexBuffer.Builder.IndexType.UINT)
+        }.build(engine)
+
+        return build(vertexBuffer, indexBuffer).apply {
+            setBufferVertices(engine, vertices)
+            setBufferIndices(engine, submeshes)
+        }
+    }
+
+    fun build(sceneView: SceneView) = build(sceneView.engine).also {
+        sceneView.geometries += it
+    }
+
+    internal abstract fun build(vertexBuffer: VertexBuffer, indexBuffer: IndexBuffer): T
 }
 
 val List<Geometry.Vertex>.hasNormals get() = any { it.normal != null }

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Geometry.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Geometry.kt
@@ -239,8 +239,8 @@ abstract class BaseGeometryBuilder<T : Geometry> internal constructor(
         }.build(engine)
 
         return build(vertexBuffer, indexBuffer).apply {
-            setBufferVertices(engine, vertices)
-            setBufferIndices(engine, submeshes)
+            setBufferVertices(engine, this@BaseGeometryBuilder.vertices)
+            setBufferIndices(engine, this@BaseGeometryBuilder.submeshes)
         }
     }
 

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Plane.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Plane.kt
@@ -34,7 +34,7 @@ class Plane private constructor(
         val size: Size = Size(x = 2.0f, y = 2.0f),
         val center: Position = Position(0.0f),
         val normal: Direction = Direction(y = 1.0f) // Looking upper
-    ) : BaseBuilder<Plane>(
+    ) : BaseGeometryBuilder<Plane>(
         vertices = getVertices(center, size, normal),
         submeshes = mutableListOf(
             Geometry.Submesh(

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Sphere.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/geometries/Sphere.kt
@@ -34,7 +34,7 @@ class Sphere(
         val center: Position = Position(0.0f),
         val stacks: Int = 24,
         val slices: Int = 24
-    ) : BaseBuilder<Sphere>(
+    ) : BaseGeometryBuilder<Sphere>(
         vertices = mutableListOf<Vertex>().apply {
             for (stack in 0..stacks) {
                 val phi = PI * stack.toFloat() / stacks.toFloat()

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/nodes/ViewNode.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/nodes/ViewNode.kt
@@ -18,6 +18,7 @@ import io.github.sceneview.loaders.MaterialLoader
 import io.github.sceneview.managers.NodeManager
 import io.github.sceneview.managers.WindowViewManager
 import io.github.sceneview.managers.geometry
+import io.github.sceneview.managers.setGeometry
 import io.github.sceneview.math.Direction
 import io.github.sceneview.math.size
 import io.github.sceneview.texture.ViewStream
@@ -79,7 +80,11 @@ class ViewNode constructor(
 
         viewStream.onSizeChanged = { size ->
             geometry.update(engine, size = size)
-            renderView()
+            if (engine.renderableManager.hasComponent(entity)) {
+                engine.renderableManager.setGeometry(entity, geometry)
+            } else {
+                renderView()
+            }
         }
 
         renderView()

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/nodes/ViewNode.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/nodes/ViewNode.kt
@@ -3,8 +3,13 @@ package io.github.sceneview.nodes
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
-import com.google.android.filament.*
+import com.google.android.filament.Engine
+import com.google.android.filament.EntityManager
+import com.google.android.filament.MaterialInstance
+import com.google.android.filament.RenderableManager
+import com.google.android.filament.Texture
 import com.google.android.filament.View.PickingQueryResult
+import dev.romainguy.kotlin.math.Float3
 import io.github.sceneview.SceneView
 import io.github.sceneview.components.RenderableComponent
 import io.github.sceneview.geometries.Plane
@@ -14,10 +19,10 @@ import io.github.sceneview.managers.NodeManager
 import io.github.sceneview.managers.WindowViewManager
 import io.github.sceneview.managers.geometry
 import io.github.sceneview.math.Direction
+import io.github.sceneview.math.size
 import io.github.sceneview.texture.ViewStream
 import io.github.sceneview.texture.ViewTexture
 import io.github.sceneview.texture.destroyViewStream
-import kotlin.math.absoluteValue
 
 /**
  * A Node that can display an Android [View]
@@ -63,8 +68,8 @@ class ViewNode constructor(
 
         material = materialLoader.createViewMaterial(texture, unlit, invertFrontFaceWinding)
 
-        val drawView: () -> Unit = {
-            if (viewStream.worldSize.x.absoluteValue != 0.0f && viewStream.worldSize.y.absoluteValue != 0.0f) {
+        val renderView: () -> Unit = {
+            if (geometry.boundingBox.size != Float3(0f)) {
                 RenderableManager.Builder(geometry.submeshes.size)
                     .geometry(geometry)
                     .material(0, material)
@@ -74,10 +79,10 @@ class ViewNode constructor(
 
         viewStream.onSizeChanged = { size ->
             geometry.update(engine, size = size)
-            drawView()
+            renderView()
         }
 
-        drawView()
+        renderView()
     }
 
     constructor(


### PR DESCRIPTION
### Fix ViewNode Crashes

1- Fix lateinit property vertices on ViewNode init 
```
kotlin.UninitializedPropertyAccessException: lateinit property vertices has not been initialized
at io.github.sceneview.geometries.Geometry.getVertices(Geometry.kt:67)
at io.github.sceneview.geometries.Geometry$BaseBuilder.build(Geometry.kt:156)
            at io.github.sceneview.nodes.ViewNode.<init>(ViewNode.kt:56)
            at io.github.sceneview.nodes.ViewNode.<init>(ViewNode.kt:76)
            at io.github.sceneview.nodes.ViewNode.<init>(ViewNode.kt:91)
            at io.github.sceneview.nodes.ViewNode.<init>(ViewNode.kt:86)
```

2- Fix Filament AABB can't be empty on `geometry.boundingBox` equal 0
```
E  Panic in build:312
reason: [entity=287] AABB can't be empty, unless culling is disabled and the object is not a shadow caster/receiver
```