### PR TITLE
Fixed projection to screen space

### DIFF
--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/math/Math.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/math/Math.kt
@@ -29,7 +29,23 @@ fun FloatArray.toDirection() = this.let { (x, y, z) -> Direction(x, y, z) }
 fun FloatArray.toQuaternion() = this.let { (x, y, z, w) -> Quaternion(x, y, z, w) }
 fun FloatArray.toSize() = this.let { (x, y, z) -> Size(x, y, z) }
 fun FloatArray.toTransform() = Transform.of(*this)
+/**
+ * Converts a column-major [FloatArray] to a [Transform]
+ */
+fun FloatArray.toTransformTransposed(): Transform {
+    require(size >= 16)
+    return Transform(
+        Float4(this[0], this[1], this[2], this[3]),
+        Float4(this[4], this[5], this[6], this[7]),
+        Float4(this[8], this[9], this[10], this[11]),
+        Float4(this[12], this[13], this[14], this[15])
+    )
+}
 fun DoubleArray.toTransform() = Transform.of(*this.map { it.toFloat() }.toFloatArray())
+/**
+ * Converts a column-major [DoubleArray] to a [Transform]
+ */
+fun DoubleArray.toTransformTransposed() = this.map { it.toFloat() }.toFloatArray().toTransformTransposed()
 fun Mat4.toDoubleArray() : DoubleArray = toFloatArray().map { it.toDouble() }.toDoubleArray()
 val Mat4.quaternion: Quaternion get() = rotation(this).toQuaternion()
 

--- a/sceneview_1_0_0/src/main/java/io/github/sceneview/scene/Camera.kt
+++ b/sceneview_1_0_0/src/main/java/io/github/sceneview/scene/Camera.kt
@@ -89,7 +89,7 @@ fun Camera.luminance(ev100: Float) = pow(2.0f, ev100 - 3.0f)
  * This is why it may differ from the matrix set through setProjection() or setLensProjection().
  */
 val Camera.projectionMatrix
-    get() = DoubleArray(16).apply { getProjectionMatrix(this) }.toTransform()
+    get() = DoubleArray(16).apply { getProjectionMatrix(this) }.toTransformTransposed()
 
 fun Camera.setCustomProjection(transform: Transform, near: Float, far: Float) =
     setCustomProjection(
@@ -101,7 +101,7 @@ fun Camera.setCustomProjection(transform: Transform, near: Float, far: Float) =
 /**
  * The camera's view matrix. The view matrix is the inverse of the model matrix
  */
-val Camera.viewMatrix get() = FloatArray(16).apply { getViewMatrix(this) }.toTransform()
+val Camera.viewMatrix get() = FloatArray(16).apply { getViewMatrix(this) }.toTransformTransposed()
 
 /**
  * The camera's model matrix. The model matrix encodes the camera position and orientation, or pose
@@ -140,7 +140,7 @@ fun Camera.viewSpaceToWorld(viewSpacePosition: Position): Position =
  * @see clipSpaceToViewPort
  */
 fun Camera.worldToViewSpace(worldPosition: Position): Position =
-    (projectionMatrix * viewMatrix) * worldPosition
+    viewMatrix * worldPosition
 
 
 /**


### PR DESCRIPTION
Closes #290

The problem was introduced in two places:

- By using column-major arrays as row-major arrays when getting matrices from Filament
- By performing a redundant multiplication by the projection matrix when converting a world position to the view space