### PR TITLE
Added back missing `materialInstance` value in BaseGeometryNode<T>

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
@@ -43,6 +43,7 @@ open class CubeNode(
         .size(size)
         .center(center)
         .build(engine),
+    materialInstance = materialInstance,
     materialInstances = materialInstances,
     parent = parent,
     renderableApply = renderableApply

--- a/sceneview/src/main/java/io/github/sceneview/node/ImageNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ImageNode.kt
@@ -34,7 +34,7 @@ open class ImageNode(
     size = size,
     center = center,
     normal = normal,
-    materialInstances = { imageMaterial.instance },
+    materialInstance = imageMaterial.instance,
     parent = parent,
     renderableApply = renderableApply
 ) {

--- a/sceneview/src/main/java/io/github/sceneview/node/VideoNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/VideoNode.kt
@@ -38,7 +38,7 @@ open class VideoNode(
     size = size,
     center = center,
     normal = normal,
-    materialInstances = { videoMaterial.instance },
+    materialInstance = videoMaterial.instance,
     parent = parent,
     renderableApply = renderableApply
 ) {


### PR DESCRIPTION
`materialInstance` is found to be `null` in BaseGeometryNode<T> for `CubeNode`, `ImageNode` and `VideoNode`. 
It is because `materialInstances` is set with value but `materialInstance` is not.