### PR TITLE
Separated to two constructors

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
@@ -13,10 +13,6 @@ open class CubeNode(
     size: Size = Cube.DEFAULT_SIZE,
     center: Position = Cube.DEFAULT_CENTER,
     /**
-     * Binds a material instance to all primitives.
-     */
-    materialInstance: MaterialInstance? = null,
-    /**
      * Binds a material instance to the specified primitive.
      *
      * If no material is specified for a given primitive, Filament will fall back to a basic
@@ -25,7 +21,7 @@ open class CubeNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance? = { materialInstance },
+    materialInstances: (index: Int) -> MaterialInstance,
     /**
      * The parent node.
      *
@@ -48,6 +44,26 @@ open class CubeNode(
     parent = parent,
     renderableApply = renderableApply
 ) {
+
+    constructor(
+        engine: Engine,
+        size: Size = Cube.DEFAULT_SIZE,
+        center: Position = Cube.DEFAULT_CENTER,
+        /**
+         * Binds a material instance to all primitives.
+         */
+        materialInstance: MaterialInstance,
+        parent: Node? = null,
+        renderableApply: RenderableManager.Builder.() -> Unit = {}
+    ) : this(
+        engine = engine,
+        size = size,
+        center = center,
+        materialInstances = { materialInstance },
+        parent = parent,
+        renderableApply = renderableApply
+    )
+
     val center get() = geometry.center
     val size get() = geometry.size
 

--- a/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
@@ -39,7 +39,6 @@ open class CubeNode(
         .size(size)
         .center(center)
         .build(engine),
-    materialInstance = materialInstance,
     materialInstances = materialInstances,
     parent = parent,
     renderableApply = renderableApply

--- a/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CubeNode.kt
@@ -21,7 +21,7 @@ open class CubeNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance,
+    materialInstances: (index: Int) -> MaterialInstance?,
     /**
      * The parent node.
      *
@@ -51,7 +51,7 @@ open class CubeNode(
         /**
          * Binds a material instance to all primitives.
          */
-        materialInstance: MaterialInstance,
+        materialInstance: MaterialInstance?,
         parent: Node? = null,
         renderableApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(

--- a/sceneview/src/main/java/io/github/sceneview/node/CylinderNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CylinderNode.kt
@@ -14,10 +14,6 @@ open class CylinderNode(
     center: Position,
     sideCount: Int,
     /**
-     * Binds a material instance to all primitives.
-     */
-    materialInstance: MaterialInstance? = null,
-    /**
      * Binds a material instance to the specified primitive.
      *
      * If no material is specified for a given primitive, Filament will fall back to a basic
@@ -26,7 +22,7 @@ open class CylinderNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance? = { materialInstance },
+    materialInstances: (index: Int) -> MaterialInstance,
     /**
      * The parent node.
      *
@@ -46,11 +42,34 @@ open class CylinderNode(
         .center(center)
         .sideCount(sideCount)
         .build(engine),
-    materialInstance = materialInstance,
     materialInstances = materialInstances,
     parent = parent,
     renderableApply = renderableApply
 ) {
+
+    constructor(
+        engine: Engine,
+        radius: Float,
+        height: Float,
+        center: Position,
+        sideCount: Int,
+        /**
+         * Binds a material instance to all primitives.
+         */
+        materialInstance: MaterialInstance,
+        parent: Node? = null,
+        renderableApply: RenderableManager.Builder.() -> Unit = {}
+    ) : this(
+        engine = engine,
+        radius = radius,
+        height = height,
+        center = center,
+        sideCount = sideCount,
+        materialInstances = { materialInstance },
+        parent = parent,
+        renderableApply = renderableApply
+    )
+
     val radius get() = geometry.radius
     val height get() = geometry.height
     val center get() = geometry.center

--- a/sceneview/src/main/java/io/github/sceneview/node/CylinderNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CylinderNode.kt
@@ -22,7 +22,7 @@ open class CylinderNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance,
+    materialInstances: (index: Int) -> MaterialInstance?,
     /**
      * The parent node.
      *
@@ -56,7 +56,7 @@ open class CylinderNode(
         /**
          * Binds a material instance to all primitives.
          */
-        materialInstance: MaterialInstance,
+        materialInstance: MaterialInstance?,
         parent: Node? = null,
         renderableApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(

--- a/sceneview/src/main/java/io/github/sceneview/node/CylinderNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CylinderNode.kt
@@ -9,10 +9,10 @@ import io.github.sceneview.math.Position
 
 open class CylinderNode(
     engine: Engine,
-    radius: Float,
-    height: Float,
-    center: Position,
-    sideCount: Int,
+    radius: Float = Cylinder.DEFAULT_RADIUS,
+    height: Float = Cylinder.DEFAULT_HEIGHT,
+    center: Position = Cylinder.DEFAULT_CENTER,
+    sideCount: Int = Cylinder.DEFAULT_SIDE_COUNT,
     /**
      * Binds a material instance to the specified primitive.
      *
@@ -49,10 +49,10 @@ open class CylinderNode(
 
     constructor(
         engine: Engine,
-        radius: Float,
-        height: Float,
-        center: Position,
-        sideCount: Int,
+        radius: Float = Cylinder.DEFAULT_RADIUS,
+        height: Float = Cylinder.DEFAULT_HEIGHT,
+        center: Position = Cylinder.DEFAULT_CENTER,
+        sideCount: Int = Cylinder.DEFAULT_SIDE_COUNT,
         /**
          * Binds a material instance to all primitives.
          */

--- a/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
@@ -45,7 +45,7 @@ open class GeometryNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance,
+    materialInstances: (index: Int) -> MaterialInstance?,
     /**
      * The parent node.
      *
@@ -75,7 +75,7 @@ open class GeometryNode(
         /**
          * Binds a material instance to all primitives.
          */
-        materialInstance: MaterialInstance,
+        materialInstance: MaterialInstance?,
         parent: Node? = null,
         renderableApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(
@@ -105,7 +105,7 @@ open class BaseGeometryNode<T : Geometry>(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance,
+    materialInstances: (index: Int) -> MaterialInstance?,
     /**
      * The parent node.
      *
@@ -125,7 +125,7 @@ open class BaseGeometryNode<T : Geometry>(
         /**
          * Binds a material instance to all primitives.
          */
-        materialInstance: MaterialInstance,
+        materialInstance: MaterialInstance?,
         parent: Node? = null,
         renderableApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(
@@ -141,7 +141,7 @@ open class BaseGeometryNode<T : Geometry>(
             .geometry(geometry)
             .apply {
                 geometry.submeshes.forEachIndexed { index, _ ->
-                    material(index, materialInstances(index))
+                    materialInstances(index)?.let { material(index, it) }
                 }
             }
             .apply(renderableApply)

--- a/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
@@ -37,10 +37,6 @@ open class GeometryNode(
     vertices: List<Geometry.Vertex> = listOf(),
     submeshes: List<Geometry.Submesh> = listOf(),
     /**
-     * Binds a material instance to all primitives.
-     */
-    materialInstance: MaterialInstance? = null,
-    /**
      * Binds a material instance to the specified primitive.
      *
      * If no material is specified for a given primitive, Filament will fall back to a basic
@@ -49,7 +45,7 @@ open class GeometryNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance? = { materialInstance },
+    materialInstances: (index: Int) -> MaterialInstance,
     /**
      * The parent node.
      *
@@ -67,12 +63,30 @@ open class GeometryNode(
         .vertices(vertices)
         .submeshes(submeshes)
         .build(engine),
-    materialInstance = materialInstance,
     materialInstances = materialInstances,
     parent = parent,
     renderableApply = renderableApply
 ) {
-    val vertexBuffer get() = geometry.vertexBuffer
+
+    constructor(
+        engine: Engine,
+        vertices: List<Geometry.Vertex> = listOf(),
+        submeshes: List<Geometry.Submesh> = listOf(),
+        /**
+         * Binds a material instance to all primitives.
+         */
+        materialInstance: MaterialInstance,
+        parent: Node? = null,
+        renderableApply: RenderableManager.Builder.() -> Unit = {}
+    ) : this(
+        engine = engine,
+        vertices = vertices,
+        submeshes = submeshes,
+        materialInstances = { materialInstance },
+        parent = parent,
+        renderableApply = renderableApply
+    )
+
     val indexBuffer get() = geometry.indexBuffer
 
     fun setVertices(vertices: List<Geometry.Vertex>) = geometry.setVertices(vertices)
@@ -83,10 +97,6 @@ open class BaseGeometryNode<T : Geometry>(
     engine: Engine,
     val geometry: T,
     /**
-     * Binds a material instance to all primitives.
-     */
-    materialInstance: MaterialInstance? = null,
-    /**
      * Binds a material instance to the specified primitive.
      *
      * If no material is specified for a given primitive, Filament will fall back to a basic
@@ -95,7 +105,7 @@ open class BaseGeometryNode<T : Geometry>(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance? = { materialInstance },
+    materialInstances: (index: Int) -> MaterialInstance,
     /**
      * The parent node.
      *
@@ -109,12 +119,29 @@ open class BaseGeometryNode<T : Geometry>(
     renderableApply: RenderableManager.Builder.() -> Unit = {}
 ) : RenderableNode(engine = engine, parent = parent) {
 
+    constructor(
+        engine: Engine,
+        geometry: T,
+        /**
+         * Binds a material instance to all primitives.
+         */
+        materialInstance: MaterialInstance,
+        parent: Node? = null,
+        renderableApply: RenderableManager.Builder.() -> Unit = {}
+    ) : this(
+        engine = engine,
+        geometry = geometry,
+        materialInstances = { materialInstance },
+        parent = parent,
+        renderableApply = renderableApply
+    )
+
     init {
         RenderableManager.Builder(geometry.submeshes.size)
             .geometry(geometry)
             .apply {
                 geometry.submeshes.forEachIndexed { index, _ ->
-                    materialInstances(index)?.let { material(index, it) }
+                    material(index, materialInstances(index))
                 }
             }
             .apply(renderableApply)

--- a/sceneview/src/main/java/io/github/sceneview/node/PlaneNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/PlaneNode.kt
@@ -15,10 +15,6 @@ open class PlaneNode(
     center: Position = Plane.DEFAULT_CENTER,
     normal: Direction = Plane.DEFAULT_NORMAL,
     /**
-     * Binds a material instance to all primitives.
-     */
-    materialInstance: MaterialInstance? = null,
-    /**
      * Binds a material instance to the specified primitive.
      *
      * If no material is specified for a given primitive, Filament will fall back to a basic
@@ -27,7 +23,7 @@ open class PlaneNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance? = { materialInstance },
+    materialInstances: (index: Int) -> MaterialInstance,
     /**
      * The parent node.
      *
@@ -46,11 +42,32 @@ open class PlaneNode(
         .center(center)
         .normal(normal)
         .build(engine),
-    materialInstance = materialInstance,
     materialInstances = materialInstances,
     parent = parent,
     renderableApply = renderableApply
 ) {
+
+    constructor(
+        engine: Engine,
+        size: Size = Plane.DEFAULT_SIZE,
+        center: Position = Plane.DEFAULT_CENTER,
+        normal: Direction = Plane.DEFAULT_NORMAL,
+        /**
+         * Binds a material instance to all primitives.
+         */
+        materialInstance: MaterialInstance,
+        parent: Node? = null,
+        renderableApply: RenderableManager.Builder.() -> Unit = {}
+    ) : this(
+        engine = engine,
+        size = size,
+        center = center,
+        normal = normal,
+        materialInstances = { materialInstance },
+        parent = parent,
+        renderableApply = renderableApply
+    )
+
     val size get() = geometry.size
     val center get() = geometry.center
     val normal get() = geometry.normal

--- a/sceneview/src/main/java/io/github/sceneview/node/PlaneNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/PlaneNode.kt
@@ -23,7 +23,7 @@ open class PlaneNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance,
+    materialInstances: (index: Int) -> MaterialInstance?,
     /**
      * The parent node.
      *
@@ -55,7 +55,7 @@ open class PlaneNode(
         /**
          * Binds a material instance to all primitives.
          */
-        materialInstance: MaterialInstance,
+        materialInstance: MaterialInstance?,
         parent: Node? = null,
         renderableApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(

--- a/sceneview/src/main/java/io/github/sceneview/node/SphereNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/SphereNode.kt
@@ -22,7 +22,7 @@ open class SphereNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance,
+    materialInstances: (index: Int) -> MaterialInstance?,
     /**
      * The parent node.
      *
@@ -56,7 +56,7 @@ open class SphereNode(
         /**
          * Binds a material instance to all primitives.
          */
-        materialInstance: MaterialInstance,
+        materialInstance: MaterialInstance?,
         parent: Node? = null,
         renderableApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(

--- a/sceneview/src/main/java/io/github/sceneview/node/SphereNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/SphereNode.kt
@@ -9,10 +9,10 @@ import io.github.sceneview.math.Position
 
 open class SphereNode(
     engine: Engine,
-    radius: Float,
-    center: Position,
-    stacks: Int,
-    slices: Int,
+    radius: Float = Sphere.DEFAULT_RADIUS,
+    center: Position = Sphere.DEFAULT_CENTER,
+    stacks: Int = Sphere.DEFAULT_STACKS,
+    slices: Int = Sphere.DEFAULT_SLICES,
     /**
      * Binds a material instance to the specified primitive.
      *
@@ -49,10 +49,10 @@ open class SphereNode(
 
     constructor(
         engine: Engine,
-        radius: Float,
-        center: Position,
-        stacks: Int,
-        slices: Int,
+        radius: Float = Sphere.DEFAULT_RADIUS,
+        center: Position = Sphere.DEFAULT_CENTER,
+        stacks: Int = Sphere.DEFAULT_STACKS,
+        slices: Int = Sphere.DEFAULT_SLICES,
         /**
          * Binds a material instance to all primitives.
          */

--- a/sceneview/src/main/java/io/github/sceneview/node/SphereNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/SphereNode.kt
@@ -14,10 +14,6 @@ open class SphereNode(
     stacks: Int,
     slices: Int,
     /**
-     * Binds a material instance to all primitives.
-     */
-    materialInstance: MaterialInstance? = null,
-    /**
      * Binds a material instance to the specified primitive.
      *
      * If no material is specified for a given primitive, Filament will fall back to a basic
@@ -26,7 +22,7 @@ open class SphereNode(
      * Should return the material to bind for the zero-based index of the primitive, must be less
      * than the [Geometry.submeshes] size passed to constructor.
      */
-    materialInstances: (index: Int) -> MaterialInstance? = { materialInstance },
+    materialInstances: (index: Int) -> MaterialInstance,
     /**
      * The parent node.
      *
@@ -46,11 +42,34 @@ open class SphereNode(
         .stacks(stacks)
         .slices(slices)
         .build(engine),
-    materialInstance = materialInstance,
     materialInstances = materialInstances,
     parent = parent,
     renderableApply = renderableApply
 ) {
+
+    constructor(
+        engine: Engine,
+        radius: Float,
+        center: Position,
+        stacks: Int,
+        slices: Int,
+        /**
+         * Binds a material instance to all primitives.
+         */
+        materialInstance: MaterialInstance,
+        parent: Node? = null,
+        renderableApply: RenderableManager.Builder.() -> Unit = {}
+    ) : this(
+        engine = engine,
+        radius = radius,
+        center = center,
+        stacks = stacks,
+        slices = slices,
+        materialInstances = { materialInstance },
+        parent = parent,
+        renderableApply = renderableApply
+    )
+
     val radius get() = geometry.radius
     val center get() = geometry.center
     val stacks get() = geometry.stacks


### PR DESCRIPTION
Separated BaseGeometryNode to two constructors. One with `materialInstance ` that binds a material instance to all primitives, while the other with `materialInstances ` that binds one material instance to each face.