### PR TITLE
fix cylinder submeshes error

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/geometries/Cylinder.kt
+++ b/sceneview/src/main/java/io/github/sceneview/geometries/Cylinder.kt
@@ -198,8 +198,8 @@ class Cylinder(
                 val bottomRight = side + 1
                 val topLeft = side + sideCount + 1
                 val topRight = side + sideCount + 2
-                val lowerCenterIndex = 2 * sideCount
-                val upperCenterIndex = lowerCenterIndex + 1 + sideCount
+                val lowerCenterIndex = 2 * (sideCount + 1)
+                val upperCenterIndex = lowerCenterIndex + sideCount + 2
 
                 add(
                     Submesh(
@@ -218,7 +218,7 @@ class Cylinder(
                         // Add top cap triangle
                         upperCenterIndex,
                         upperCenterIndex + side + 2,
-                        lowerCenterIndex + side + 1
+                        upperCenterIndex + side + 1
                     )
                 )
             }


### PR DESCRIPTION
fixed the problem of CylinderNode building wrong model

original:
![original](https://github.com/SceneView/sceneview-android/assets/65711439/4196fec7-de73-4e58-b7fc-ab5f1fa04ba9)

fixed:
![fixed](https://github.com/SceneView/sceneview-android/assets/65711439/42c85112-073b-4766-9789-d3640177bd6d)