### PR TITLE
Supporting minSdk 23

### DIFF
--- a/arsceneview/build.gradle
+++ b/arsceneview/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdk 24
+        minSdk 23
         targetSdk 34
 
         consumerProguardFiles "consumer-rules.pro"

--- a/sceneview/build.gradle
+++ b/sceneview/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        minSdk 24
+        minSdk 23
         targetSdk 34
 
         consumerProguardFiles 'consumer-rules.pro'


### PR DESCRIPTION
Hello SceneView team 👋 

## What has been changed

Setting the `minSdk` version to 23 from 24.

## Why it's required

We (Trade Republic) cannot upgrade our minimum SDK version easily. 
We've to inform users still using this version with 3 months prior, if we wanted to upgrade the minSdk version.
If I want to promote to adopt this Open Source project, then I need to resolve this only problem.

## Related issue

There was a discussion about lowering minSdk before in this issue: https://github.com/SceneView/sceneview-android/issues/37

## Screenshots after the change

AR view | 3D view | 
------ | ------ | 
<img src="https://github.com/SceneView/sceneview-android/assets/2279811/a8fd4d39-9ab0-4e17-9d20-7e878d503256" width="300"/> | <video src="https://github.com/SceneView/sceneview-android/assets/2279811/fe1cd7fa-9a5a-46df-9f49-eeb811309087"/>

Thank you for providing replacement for the Sceneform!