### PR TITLE
Moved flatbuffers to under sceneview to avoid duplicate class conflicts

### DIFF
--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/AabbDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/AabbDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class AabbDef extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ArcDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ArcDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/BlendShape.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/BlendShape.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -71,13 +71,13 @@ public final class BlendShape extends Table {
   public ByteBuffer tangentIndices16InByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 16, 2); }
 
   public static int createBlendShape(FlatBufferBuilder builder,
-      long name,
-      int vertex_dataOffset,
-      int vertex_indices32Offset,
-      int vertex_indices16Offset,
-      int tangent_dataOffset,
-      int tangent_indices32Offset,
-      int tangent_indices16Offset) {
+                                     long name,
+                                     int vertex_dataOffset,
+                                     int vertex_indices32Offset,
+                                     int vertex_indices16Offset,
+                                     int tangent_dataOffset,
+                                     int tangent_indices32Offset,
+                                     int tangent_indices16Offset) {
     builder.startObject(7);
     BlendShape.addTangentIndices16(builder, tangent_indices16Offset);
     BlendShape.addTangentIndices32(builder, tangent_indices32Offset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Color.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Color.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Color extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataBool.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataBool.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -20,7 +20,7 @@ public final class DataBool extends Table {
   public boolean value() { int o = __offset(4); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
 
   public static int createDataBool(FlatBufferBuilder builder,
-      boolean value) {
+                                   boolean value) {
     builder.startObject(1);
     DataBool.addValue(builder, value);
     return DataBool.endDataBool(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataBytes.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataBytes.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -23,7 +23,7 @@ public final class DataBytes extends Table {
   public ByteBuffer valueInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
 
   public static int createDataBytes(FlatBufferBuilder builder,
-      int valueOffset) {
+                                    int valueOffset) {
     builder.startObject(1);
     DataBytes.addValue(builder, valueOffset);
     return DataBytes.endDataBytes(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataFloat.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataFloat.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -20,7 +20,7 @@ public final class DataFloat extends Table {
   public float value() { int o = __offset(4); return o != 0 ? bb.getFloat(o + bb_pos) : 0.0f; }
 
   public static int createDataFloat(FlatBufferBuilder builder,
-      float value) {
+                                    float value) {
     builder.startObject(1);
     DataFloat.addValue(builder, value);
     return DataFloat.endDataFloat(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataHashValue.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataHashValue.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -20,7 +20,7 @@ public final class DataHashValue extends Table {
   public long value() { int o = __offset(4); return o != 0 ? (long)bb.getInt(o + bb_pos) & 0xFFFFFFFFL : 0L; }
 
   public static int createDataHashValue(FlatBufferBuilder builder,
-      long value) {
+                                        long value) {
     builder.startObject(1);
     DataHashValue.addValue(builder, value);
     return DataHashValue.endDataHashValue(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataInt.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataInt.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -20,7 +20,7 @@ public final class DataInt extends Table {
   public int value() { int o = __offset(4); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
 
   public static int createDataInt(FlatBufferBuilder builder,
-      int value) {
+                                  int value) {
     builder.startObject(1);
     DataInt.addValue(builder, value);
     return DataInt.endDataInt(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataQuat.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataQuat.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataString.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataString.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -22,7 +22,7 @@ public final class DataString extends Table {
   public ByteBuffer valueInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
 
   public static int createDataString(FlatBufferBuilder builder,
-      int valueOffset) {
+                                     int valueOffset) {
     builder.startObject(1);
     DataString.addValue(builder, valueOffset);
     return DataString.endDataString(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataVec2.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataVec2.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataVec3.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataVec3.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataVec4.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/DataVec4.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/KeyVariantPairDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/KeyVariantPairDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -26,10 +26,10 @@ public final class KeyVariantPairDef extends Table {
   public Table value(Table obj) { int o = __offset(10); return o != 0 ? __union(obj, o) : null; }
 
   public static int createKeyVariantPairDef(FlatBufferBuilder builder,
-      int keyOffset,
-      long hash_key,
-      byte value_type,
-      int valueOffset) {
+                                            int keyOffset,
+                                            long hash_key,
+                                            byte value_type,
+                                            int valueOffset) {
     builder.startObject(4);
     KeyVariantPairDef.addValue(builder, valueOffset);
     KeyVariantPairDef.addHashKey(builder, hash_key);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Mat4x3.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Mat4x3.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Mat4x3 extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/MaterialDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/MaterialDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -40,9 +40,9 @@ public final class MaterialDef extends Table {
   public int texturesLength() { int o = __offset(8); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createMaterialDef(FlatBufferBuilder builder,
-      int nameOffset,
-      int propertiesOffset,
-      int texturesOffset) {
+                                      int nameOffset,
+                                      int propertiesOffset,
+                                      int texturesOffset) {
     builder.startObject(3);
     MaterialDef.addTextures(builder, texturesOffset);
     MaterialDef.addProperties(builder, propertiesOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/MaterialTextureDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/MaterialTextureDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 public final class MaterialTextureDef extends Table {
@@ -28,9 +28,9 @@ public final class MaterialTextureDef extends Table {
   public ByteBuffer usagePerChannelInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 8, 4); }
 
   public static int createMaterialTextureDef(FlatBufferBuilder builder,
-      int nameOffset,
-      int usage,
-      int usage_per_channelOffset) {
+                                             int nameOffset,
+                                             int usage,
+                                             int usage_per_channelOffset) {
     builder.startObject(3);
     MaterialTextureDef.addUsagePerChannel(builder, usage_per_channelOffset);
     MaterialTextureDef.addUsage(builder, usage);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelIndexRange.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelIndexRange.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelInstanceDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelInstanceDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -91,18 +91,18 @@ public final class ModelInstanceDef extends Table {
   public int aabbsLength() { int o = __offset(26); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createModelInstanceDef(FlatBufferBuilder builder,
-      int vertex_dataOffset,
-      int indices16Offset,
-      int indices32Offset,
-      int rangesOffset,
-      int materialsOffset,
-      int vertex_attributesOffset,
-      long num_vertices,
-      boolean interleaved,
-      int shader_to_mesh_bonesOffset,
-      int blend_shapesOffset,
-      int blend_attributesOffset,
-      int aabbsOffset) {
+                                           int vertex_dataOffset,
+                                           int indices16Offset,
+                                           int indices32Offset,
+                                           int rangesOffset,
+                                           int materialsOffset,
+                                           int vertex_attributesOffset,
+                                           long num_vertices,
+                                           boolean interleaved,
+                                           int shader_to_mesh_bonesOffset,
+                                           int blend_shapesOffset,
+                                           int blend_attributesOffset,
+                                           int aabbsOffset) {
     builder.startObject(12);
     ModelInstanceDef.addAabbs(builder, aabbsOffset);
     ModelInstanceDef.addBlendAttributes(builder, blend_attributesOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineCollidableDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineCollidableDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -25,7 +25,7 @@ public final class ModelPipelineCollidableDef extends Table {
   public ByteBuffer sourceInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
 
   public static int createModelPipelineCollidableDef(FlatBufferBuilder builder,
-      int sourceOffset) {
+                                                     int sourceOffset) {
     builder.startObject(1);
     ModelPipelineCollidableDef.addSource(builder, sourceOffset);
     return ModelPipelineCollidableDef.endModelPipelineCollidableDef(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -49,11 +49,11 @@ public final class ModelPipelineDef extends Table {
   public int texturesLength() { int o = __offset(12); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createModelPipelineDef(FlatBufferBuilder builder,
-      int sourcesOffset,
-      int renderablesOffset,
-      int collidableOffset,
-      int skeletonOffset,
-      int texturesOffset) {
+                                           int sourcesOffset,
+                                           int renderablesOffset,
+                                           int collidableOffset,
+                                           int skeletonOffset,
+                                           int texturesOffset) {
     builder.startObject(5);
     ModelPipelineDef.addTextures(builder, texturesOffset);
     ModelPipelineDef.addSkeleton(builder, skeletonOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineImportDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineImportDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -99,22 +99,22 @@ public final class ModelPipelineImportDef extends Table {
   public boolean mergeMaterials() { int o = __offset(34); return o != 0 ? 0!=bb.get(o + bb_pos) : true; }
 
   public static int createModelPipelineImportDef(FlatBufferBuilder builder,
-      int nameOffset,
-      int fileOffset,
-      boolean recenter,
-      float scale,
-      int axis_system,
-      float smoothing_angle,
-      int max_bone_weights,
-      boolean report_errors_to_stdout,
-      boolean flip_texture_coordinates,
-      boolean flatten_hierarchy_and_transform_vertices_to_root_space,
-      boolean use_specular_glossiness_textures_if_present,
-      boolean fix_infacing_normals,
-      boolean ensure_vertex_orientation_w_not_zero,
-      float cm_per_unit,
-      int target_meshesOffset,
-      boolean merge_materials) {
+                                                 int nameOffset,
+                                                 int fileOffset,
+                                                 boolean recenter,
+                                                 float scale,
+                                                 int axis_system,
+                                                 float smoothing_angle,
+                                                 int max_bone_weights,
+                                                 boolean report_errors_to_stdout,
+                                                 boolean flip_texture_coordinates,
+                                                 boolean flatten_hierarchy_and_transform_vertices_to_root_space,
+                                                 boolean use_specular_glossiness_textures_if_present,
+                                                 boolean fix_infacing_normals,
+                                                 boolean ensure_vertex_orientation_w_not_zero,
+                                                 float cm_per_unit,
+                                                 int target_meshesOffset,
+                                                 boolean merge_materials) {
     builder.startObject(16);
     ModelPipelineImportDef.addTargetMeshes(builder, target_meshesOffset);
     ModelPipelineImportDef.addCmPerUnit(builder, cm_per_unit);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineMaterialDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineMaterialDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -30,8 +30,8 @@ public final class ModelPipelineMaterialDef extends Table {
   public ByteBuffer nameOverrideInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 6, 1); }
 
   public static int createModelPipelineMaterialDef(FlatBufferBuilder builder,
-      int materialOffset,
-      int name_overrideOffset) {
+                                                   int materialOffset,
+                                                   int name_overrideOffset) {
     builder.startObject(2);
     ModelPipelineMaterialDef.addNameOverride(builder, name_overrideOffset);
     ModelPipelineMaterialDef.addMaterial(builder, materialOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineRenderableDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineRenderableDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -41,9 +41,9 @@ public final class ModelPipelineRenderableDef extends Table {
   public ByteBuffer attributesInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 8, 4); }
 
   public static int createModelPipelineRenderableDef(FlatBufferBuilder builder,
-      int sourceOffset,
-      int materialsOffset,
-      int attributesOffset) {
+                                                     int sourceOffset,
+                                                     int materialsOffset,
+                                                     int attributesOffset) {
     builder.startObject(3);
     ModelPipelineRenderableDef.addAttributes(builder, attributesOffset);
     ModelPipelineRenderableDef.addMaterials(builder, materialsOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineSkeletonDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/ModelPipelineSkeletonDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -25,7 +25,7 @@ public final class ModelPipelineSkeletonDef extends Table {
   public ByteBuffer sourceInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
 
   public static int createModelPipelineSkeletonDef(FlatBufferBuilder builder,
-      int sourceOffset) {
+                                                   int sourceOffset) {
     builder.startObject(1);
     ModelPipelineSkeletonDef.addSource(builder, sourceOffset);
     return ModelPipelineSkeletonDef.endModelPipelineSkeletonDef(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Quat.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Quat.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Quat extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Rect.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Rect.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Rect extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Recti.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Recti.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Recti extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/SkeletonDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/SkeletonDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -41,9 +41,9 @@ public final class SkeletonDef extends Table {
   public int boneTransformsLength() { int o = __offset(8); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createSkeletonDef(FlatBufferBuilder builder,
-      int bone_namesOffset,
-      int bone_parentsOffset,
-      int bone_transformsOffset) {
+                                      int bone_namesOffset,
+                                      int bone_parentsOffset,
+                                      int bone_transformsOffset) {
     builder.startObject(5);
     SkeletonDef.addBoneTransforms(builder, bone_transformsOffset);
     SkeletonDef.addBoneParents(builder, bone_parentsOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/SubmeshAabb.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/SubmeshAabb.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/TextureDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/TextureDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 public final class TextureDef extends Table {
@@ -35,18 +35,18 @@ public final class TextureDef extends Table {
   public boolean isRgbm() { int o = __offset(26); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
 
   public static int createTextureDef(FlatBufferBuilder builder,
-      int nameOffset,
-      int fileOffset,
-      int dataOffset,
-      boolean generate_mipmaps,
-      boolean premultiply_alpha,
-      int min_filter,
-      int mag_filter,
-      int wrap_s,
-      int wrap_t,
-      int wrap_r,
-      int target_type,
-      boolean is_rgbm) {
+                                     int nameOffset,
+                                     int fileOffset,
+                                     int dataOffset,
+                                     boolean generate_mipmaps,
+                                     boolean premultiply_alpha,
+                                     int min_filter,
+                                     int mag_filter,
+                                     int wrap_s,
+                                     int wrap_t,
+                                     int wrap_r,
+                                     int target_type,
+                                     boolean is_rgbm) {
     builder.startObject(12);
     TextureDef.addData(builder, dataOffset);
     TextureDef.addFile(builder, fileOffset);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VariantArrayDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VariantArrayDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -22,7 +22,7 @@ public final class VariantArrayDef extends Table {
   public int valuesLength() { int o = __offset(4); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createVariantArrayDef(FlatBufferBuilder builder,
-      int valuesOffset) {
+                                          int valuesOffset) {
     builder.startObject(1);
     VariantArrayDef.addValues(builder, valuesOffset);
     return VariantArrayDef.endVariantArrayDef(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VariantArrayDefImpl.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VariantArrayDefImpl.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -22,8 +22,8 @@ public final class VariantArrayDefImpl extends Table {
   public Table value(Table obj) { int o = __offset(6); return o != 0 ? __union(obj, o) : null; }
 
   public static int createVariantArrayDefImpl(FlatBufferBuilder builder,
-      byte value_type,
-      int valueOffset) {
+                                              byte value_type,
+                                              int valueOffset) {
     builder.startObject(2);
     VariantArrayDefImpl.addValue(builder, valueOffset);
     VariantArrayDefImpl.addValueType(builder, value_type);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VariantMapDef.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VariantMapDef.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Table;
 
 @SuppressWarnings("unused")
 /**
@@ -22,7 +22,7 @@ public final class VariantMapDef extends Table {
   public int valuesLength() { int o = __offset(4); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createVariantMapDef(FlatBufferBuilder builder,
-      int valuesOffset) {
+                                        int valuesOffset) {
     builder.startObject(1);
     VariantMapDef.addValues(builder, valuesOffset);
     return VariantMapDef.endVariantMapDef(builder);

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec2.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec2.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Vec2 extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec2i.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec2i.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Vec2i extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec3.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec3.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Vec3 extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec4.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/Vec4.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 public final class Vec4 extends Struct {

--- a/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VertexAttribute.java
+++ b/sceneview/src/main/java/com/google/ar/sceneform/lullmodel/VertexAttribute.java
@@ -4,8 +4,8 @@ package com.google.ar.sceneform.lullmodel;
 
 import java.nio.*;
 
-import java.util.*;
-import com.google.flatbuffers.*;
+import io.github.sceneview.com.google.flatbuffers.FlatBufferBuilder;
+import io.github.sceneview.com.google.flatbuffers.Struct;
 
 @SuppressWarnings("unused")
 /**

--- a/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Constants.java
+++ b/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Constants.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.flatbuffers;
+package io.github.sceneview.com.google.flatbuffers;
 
 /// @cond FLATBUFFERS_INTERNAL
 

--- a/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/FlatBufferBuilder.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.flatbuffers;
+package io.github.sceneview.com.google.flatbuffers;
 
-import static com.google.flatbuffers.Constants.*;
+import static io.github.sceneview.com.google.flatbuffers.Constants.*;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Struct.java
+++ b/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Struct.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.flatbuffers;
+package io.github.sceneview.com.google.flatbuffers;
 
 import java.nio.ByteBuffer;
 

--- a/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Table.java
+++ b/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Table.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.flatbuffers;
+package io.github.sceneview.com.google.flatbuffers;
 
-import static com.google.flatbuffers.Constants.*;
+import static io.github.sceneview.com.google.flatbuffers.Constants.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;

--- a/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Utf8.java
+++ b/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Utf8.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.flatbuffers;
+package io.github.sceneview.com.google.flatbuffers;
 
 import java.nio.ByteBuffer;
 

--- a/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Utf8Safe.java
+++ b/sceneview/src/main/java/io/github/sceneview/com/google/flatbuffers/Utf8Safe.java
@@ -28,7 +28,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-package com.google.flatbuffers;
+package io.github.sceneview.com.google.flatbuffers;
 
 import java.nio.ByteBuffer;
 import static java.lang.Character.MAX_SURROGATE;


### PR DESCRIPTION
As it was discussed, I've moved the `flatbuffers` to under `io.gihub.sceneview.com.google.flatbuffers`. 
Moving also `com.google.ar.sceneform` was problematic and led to 
```
Supertypes of the following classes cannot be resolved. Please make sure you have the required dependencies in the classpath:
    class com.google.ar.schemas.lull.TextureDef, unresolved supertypes: com.google.flatbuffers.Table
    class com.google.ar.schemas.lull.ModelInstanceDef, unresolved supertypes: com.google.flatbuffers.Table
    class com.google.ar.schemas.sceneform.SceneformBundleDef, unresolved supertypes: com.google.flatbuffers.Table
```
As `com.google.ar.sceneform` is a very specific package and unlikely to cause any conflicts I decided not to fight the issues that appeared after I moved it and leave it as it is.
