### PR TITLE
Removes the unused RECORD_AUDIO permission from AndroidManifest

### DIFF
--- a/arsceneview/src/main/AndroidManifest.xml
+++ b/arsceneview/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <!-- Always needed for AR. -->
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application>
         <!-- Indicates that this app requires Google Play Services for AR ("AR Required") and causes


### PR DESCRIPTION
It looks like the permission was added for a sample in the past which has since been removed but the AndroidManifest still includes the permission.