### PR TITLE
call arcore.destroy off of main thread Fixes #407 

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
@@ -565,7 +565,7 @@ open class ARSceneView @JvmOverloads constructor(
 
     override fun destroy() {
         if (!isDestroyed) {
-            destroyAr()
+            destroyARCore()
 
             defaultCameraNode?.destroy()
             defaultCameraStream?.destroy()
@@ -577,7 +577,7 @@ open class ARSceneView @JvmOverloads constructor(
         super.destroy()
     }
 
-    fun destroyAr() {
+    fun destroyARCore() {
         val scope = lifecycle?.coroutineScope ?: CoroutineScope(Dispatchers.IO)
         scope.launch(Dispatchers.IO) {
             // destroy should be called off the main thread since it hangs for many seconds
@@ -608,7 +608,7 @@ open class ARSceneView @JvmOverloads constructor(
         }
 
         override fun onDestroy(owner: LifecycleOwner) {
-            destroyAr()
+            destroyARCore()
         }
     }
 

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.coroutineScope
 import com.google.android.filament.Engine
 import com.google.android.filament.IndirectLight
 import com.google.android.filament.MaterialInstance
@@ -44,6 +45,9 @@ import io.github.sceneview.model.Model
 import io.github.sceneview.model.ModelInstance
 import io.github.sceneview.node.LightNode
 import io.github.sceneview.node.Node
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * A SurfaceView that integrates with ARCore and renders a scene
@@ -561,7 +565,7 @@ open class ARSceneView @JvmOverloads constructor(
 
     override fun destroy() {
         if (!isDestroyed) {
-            arCore.destroy()
+            destroyAr()
 
             defaultCameraNode?.destroy()
             defaultCameraStream?.destroy()
@@ -571,6 +575,14 @@ open class ARSceneView @JvmOverloads constructor(
         }
 
         super.destroy()
+    }
+
+    fun destroyAr() {
+        val scope = lifecycle?.coroutineScope ?: CoroutineScope(Dispatchers.IO)
+        scope.launch(Dispatchers.IO) {
+            // destroy should be called off the main thread since it hangs for many seconds
+            arCore.destroy()
+        }
     }
 
     class DefaultARCameraNode(engine: Engine) : ARCameraNode(engine) {
@@ -596,7 +608,7 @@ open class ARSceneView @JvmOverloads constructor(
         }
 
         override fun onDestroy(owner: LifecycleOwner) {
-            arCore.destroy()
+            destroyAr()
         }
     }
 


### PR DESCRIPTION
## Problem
- getting Crashlytics reports of ANR and user reports of app hanging when closing AR activity
## Solution
- from ArCore Session documentation:
> Releases resources (a significant amount of native heap memory) used by an ARCore session.
Failure to close sessions explicitly may cause your app to run out of native memory and crash. If your app contains a single AR-enabled activity, it is recommended that you call close() from the activity's onDestroy method.
**This method will take several seconds to complete. To prevent blocking the main thread, call pause() on the main thread, and then call close() on a background thread.**

- use coroutine scope to call destroy off of MainThread

Fixes #407 