### PR TITLE
Fix ModelNode hierarchy

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/model/ModelInstance.kt
+++ b/sceneview/src/main/java/io/github/sceneview/model/ModelInstance.kt
@@ -37,6 +37,13 @@ val ModelInstance.camerasEntities: List<Entity>
 val ModelInstance.cameras: List<Camera>
     get() = entities.map { engine.getCameraComponent(it) }.filterNotNull()
 
+val ModelInstance.emptyNodeEntities: List<Entity>
+    get() = entities.filter {
+        !renderableManager.hasComponent(it) &&
+                !lightManager.hasComponent(it) &&
+                engine.getCameraComponent(it) == null
+    }
+
 /**
  * Attaches the given skin to the given node, which must have an associated mesh with
  * BONE_INDICES and BONE_WEIGHTS attributes.

--- a/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
@@ -18,6 +18,7 @@ import io.github.sceneview.model.Model
 import io.github.sceneview.model.ModelInstance
 import io.github.sceneview.model.camerasEntities
 import io.github.sceneview.model.collisionShape
+import io.github.sceneview.model.emptyNodeEntities
 import io.github.sceneview.model.engine
 import io.github.sceneview.model.getAnimationIndex
 import io.github.sceneview.model.lightEntities
@@ -96,6 +97,11 @@ open class ModelNode(
     ) : io.github.sceneview.node.CameraNode(engine = modelInstance.engine, entity = entity),
         ChildNode
 
+    inner class EmptyNode internal constructor(
+        override val modelInstance: ModelInstance, entity: Entity
+    ) : Node(engine = modelInstance.engine, entity = entity),
+        ChildNode
+
     data class PlayingAnimation(val startTime: Long = System.nanoTime(), val loop: Boolean = true)
 
     val renderableNodes = modelInstance.renderableEntities.map {
@@ -107,9 +113,12 @@ open class ModelNode(
     val cameraNodes = modelInstance.camerasEntities.map {
         CameraNode(modelInstance, it).apply { parent = this }
     }
+    val emptyNodes = modelInstance.emptyNodeEntities.map {
+        EmptyNode(modelInstance, it)
+    }
 
     val nodes: Map<String, Node> =
-        (renderableNodes + lightNodes + cameraNodes).associateBy { it.name }
+        (renderableNodes + emptyNodes + lightNodes + cameraNodes).associateBy { it.name }
 
     /**
      * The source [Model] ([FilamentAsset]) from the [ModelInstance].


### PR DESCRIPTION
Right now, ModelNode completely ignores entities without components, but these are often used to maintain specific scene hierarchy. That means files that use empty nodes to compensate transforms (like Sketchfab models) are not rendered correctly.
This fix adds such nodes to the hierarchy and maintains any relative transforms.
That was in place in the SceneView 2.0.0 implementation but, for some reason, was dropped in the new one.

```kotlin
init {
    // We use allChildEntities instead of entities because of this:
    // https://github.com/google/filament/discussions/6113
    nodes = entities.map { childEntity ->
        when {
            engine.renderableManager.hasComponent(childEntity) -> RenderableNode(
                engine,
                nodeManager,
                modelInstance,
                childEntity
            )
            engine.lightManager.hasComponent(childEntity) -> LightNode(
                engine,
                nodeManager,
                modelInstance,
                childEntity
            )
            engine.getCameraComponent(childEntity) != null -> CameraNode(
                engine,
                nodeManager,
                modelInstance,
                childEntity
            )
            else -> ChildNode(engine, nodeManager, modelInstance, childEntity)
        }
    }
}
```