### PR TITLE
Let developers define custom node name

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/Node.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/Node.kt
@@ -86,6 +86,11 @@ open class Node(
     var isHittable: Boolean = true
 
     /**
+     * ### Define your own custom name
+     */
+    var name: String? = null
+
+    /**
      * The node can be selected when a touch event happened.
      *
      * If a not touchable child [Node] is touched, we check the parent hierarchy to find the


### PR DESCRIPTION
Is there any reason why the Node `name` property is removed from the [current version](https://github.com/SceneView/sceneview-android/blob/main/sceneview/src/main/java/io/github/sceneview/node/Node.kt)? 
I just updated from [v0.10.2](https://github.com/SceneView/sceneview-android/blob/722101172c7a324844e08d9a2f841aed1da9fe88/sceneview/src/main/java/io/github/sceneview/node/Node.kt#L69)

I think the name property is beneficial, for example, in handling on-tap events. We can check which node name was tapped.