### PR TITLE
Composable destroy ArCore - crash fix

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
@@ -567,9 +567,17 @@ open class ARSceneView @JvmOverloads constructor(
 
             lightEstimator?.destroy()
             planeRenderer.destroy()
+            destroyArCore()
         }
 
         super.destroy()
+    }
+
+    private fun destroyArCore() {
+        Executors.newSingleThreadExecutor().execute {
+            // destroy should be called off the main thread since it hangs for many seconds
+            arCore.destroy()
+        }
     }
 
     class DefaultARCameraNode(engine: Engine) : ARCameraNode(engine) {
@@ -595,10 +603,7 @@ open class ARSceneView @JvmOverloads constructor(
         }
 
         override fun onDestroy(owner: LifecycleOwner) {
-            Executors.newSingleThreadExecutor().execute {
-                // destroy should be called off the main thread since it hangs for many seconds
-                arCore.destroy()
-            }
+            destroyArCore()
         }
     }
 

--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -574,6 +574,7 @@ open class SceneView @JvmOverloads constructor(
     open fun destroy() {
         if (!isDestroyed) {
             lifecycle = null
+            Choreographer.getInstance().removeFrameCallback(frameCallback)
 
             runCatching { uiHelper.detach() }
 


### PR DESCRIPTION
When ARSceneView was removed from compose ArCore was never destroyed.

Added destroyArCore function call to ARSceneView destroy method and removed current Choreographer frameCallback on SceneView destroy method.

Related to issue #440 