### PR TITLE
Re: issue#435, ensure that duplicate calls to destroy arcore are ignored

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
@@ -174,8 +174,13 @@ class ARCore(
      * more complicated lifecycle requirements: [Session.close]
      */
     fun destroy() {
-        session?.close()
-        session = null
+        session?.let {
+            synchronized(it) {
+                if (session == null) return@synchronized
+                it.close()
+                session = null
+            }
+        }
     }
 
     fun onException(exception: Exception) {


### PR DESCRIPTION
Since it takes a few seconds to destroy the arcore object, multiple calls to the method can still happen concurrently while the first is still being destroyed but before the object reference has been nullified. This should protect against that race condition.