### PR TITLE
add viewnode to ar-model-viewer sample

### DIFF
--- a/samples/ar-model-viewer/build.gradle
+++ b/samples/ar-model-viewer/build.gradle
@@ -36,6 +36,6 @@ dependencies {
     implementation project(":samples:common")
 
     // ArSceneView
-    releaseImplementation "io.github.sceneview:arsceneview:2.0.4"
+    releaseImplementation "io.github.sceneview:arsceneview:2.1.0"
     debugImplementation project(":arsceneview")
 }

--- a/samples/ar-model-viewer/src/main/res/drawable/bg_black_transparent_rounded.xml
+++ b/samples/ar-model-viewer/src/main/res/drawable/bg_black_transparent_rounded.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke android:width="1dp" android:color="#EDEDED" />
+    <solid android:color="#99000000" />
+    <corners android:radius="7dp" />
+</shape>

--- a/samples/ar-model-viewer/src/main/res/layout/view_node_label.xml
+++ b/samples/ar-model-viewer/src/main/res/layout/view_node_label.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:background="@drawable/bg_black_transparent_rounded"
+    android:gravity="center_horizontal">
+
+
+    <TextView
+        android:id="@+id/node_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="View Node Test"
+        android:textStyle="bold"
+        android:textSize="24sp"
+        android:textColor="@android:color/white"
+        />
+
+    <TextView
+        android:id="@+id/node_dist"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="100m"
+        android:textSize="20sp"
+        android:textColor="@android:color/white"
+        />
+
+</LinearLayout>


### PR DESCRIPTION
ViewNode is in high demand in terms of library functionality, it seems. Putting ViewNode in the sample code 
A) shows users how to use this functionality
B) makes it a core part of testing of the library