### PR TITLE
ModelNode: fix lightNodes and cameraNodes parent

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
@@ -116,10 +116,10 @@ open class ModelNode(
         RenderableNode(modelInstance, it)
     }
     val lightNodes = modelInstance.lightEntities.map {
-        LightNode(modelInstance, it).apply { parent = this }
+        LightNode(modelInstance, it).apply { parent = this@ModelNode }
     }
     val cameraNodes = modelInstance.camerasEntities.map {
-        CameraNode(modelInstance, it).apply { parent = this }
+        CameraNode(modelInstance, it).apply { parent = this@ModelNode }
     }
     val emptyNodes = modelInstance.emptyNodeEntities.map {
         EmptyNode(modelInstance, it)


### PR DESCRIPTION
During the `ModuleNode` creation, an incorrect parent is set to `lightNodes` and `cameraNodes`.  Without specifying a scope for `this` the LightNode and CameraNode scope is used by default (because of `apply`). As a result, the node's parent is the node itself, leading to a StackOverflow exception when traversing these nodes.