### PR TITLE
Fix crash during animation

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
@@ -418,8 +418,10 @@ open class ModelNode(
     }
 
     private fun applyAnimations(frameTimeNanos: Long) {
-        playingAnimations.forEach { (index, animation) ->
-            if (animation.speed == 0f) return@forEach
+        val iterator = playingAnimations.iterator()
+        while (iterator.hasNext()) {
+            val (index, animation) = iterator.next()
+            if (animation.speed == 0f) continue
 
             animator.let { animator ->
                 val elapsedTimeSeconds = frameTimeNanos.intervalSeconds(animation.startTime)
@@ -434,7 +436,7 @@ open class ModelNode(
                 animator.applyAnimation(index, animationTime)
 
                 if (!animation.loop && adjustedTimeSeconds >= animationDuration) {
-                    playingAnimations.remove(index)
+                    iterator.remove()
                 }
             }
         }


### PR DESCRIPTION
App crashes if we play multiple animations simultaneously because playingAnimations map is modified while it is being iterated over.