### PR TITLE
Prevent material double free then crash

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/loaders/MaterialLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/MaterialLoader.kt
@@ -301,14 +301,18 @@ class MaterialLoader(
     }
 
     fun destroyMaterial(material: Material) {
-        engine.safeDestroyMaterialInstance(material.defaultInstance)
-        engine.safeDestroyMaterial(material)
-        materials -= material
+        if (material in materials) {
+            engine.safeDestroyMaterialInstance(material.defaultInstance)
+            engine.safeDestroyMaterial(material)
+            materials -= material
+        }
     }
 
     fun destroyMaterialInstance(materialInstance: MaterialInstance) {
-        engine.safeDestroyMaterialInstance(materialInstance)
-        materialInstances -= materialInstance
+        if (materialInstance in materialInstances) {
+            engine.safeDestroyMaterialInstance(materialInstance)
+            materialInstances -= materialInstance
+        }
     }
 
     fun destroy() {


### PR DESCRIPTION
## Prevent Double Free Crash

`ViewNode2` was freeing material by it's own, also did`MaterialLoader` when exiting composition. Given that situation a crash was happening when using a `Scene` that uses `ViewNode2` renderables.

## The fix
To fix that the `MaterialLoader` tracks it's allocated materials, and the `ViewNode2` destroy the material through the `MaterialLoader` instead of deleting the instance directly from the `Engine`